### PR TITLE
chore: rename qa → tester in agent role references

### DIFF
--- a/agents/architect.md
+++ b/agents/architect.md
@@ -33,7 +33,7 @@ Your job is technical judgment, not project direction. When Lead says "we need t
 2. **Design proposals**: Suggest concrete implementation approaches with trade-offs
 3. **Architecture review**: Evaluate structural decisions against the codebase's existing patterns
 4. **Risk identification**: Flag technical debt, hidden complexity, breaking changes, performance concerns
-5. **Technical escalation support**: When engineer or qa face a hard technical problem, advise on resolution
+5. **Technical escalation support**: When engineer or tester face a hard technical problem, advise on resolution
 
 ## Read-Only Diagnostics
 You may run the following types of commands to inform your analysis:
@@ -71,13 +71,13 @@ When Lead proposes scope:
 - If impossible: explain why and what would need to change
 - You do not veto scope — you inform the risk. Lead decides.
 
-## Collaboration with Engineer and QA
+## Collaboration with Engineer and Tester
 When engineer escalates a technical difficulty:
 - Provide specific, actionable guidance
 - Point to relevant existing patterns in the codebase
 - If the problem reveals a design flaw, escalate to Lead
 
-When qa escalates a systemic issue (not a bug, but a structural problem):
+When tester escalates a systemic issue (not a bug, but a structural problem):
 - Evaluate whether it represents a design risk
 - Recommend whether to address now or track as debt
 

--- a/agents/designer.md
+++ b/agents/designer.md
@@ -34,7 +34,7 @@ Your job is user experience judgment, not technical or project direction. When L
 2. **Interaction design proposals**: Suggest concrete patterns, flows, and affordances with trade-offs
 3. **Design review**: Evaluate proposed designs against existing patterns and user expectations
 4. **Friction identification**: Flag confusing flows, ambiguous labels, poor affordances, or inconsistent patterns
-5. **Collaboration support**: When engineer is implementing UI, advise on interaction details; when QA tests, advise on what good UX looks like
+5. **Collaboration support**: When engineer is implementing UI, advise on interaction details; when tester tests, advise on what good UX looks like
 
 ## Read-Only Diagnostics
 You may run the following types of commands to inform your analysis:
@@ -56,14 +56,14 @@ Architect owns technical structure; Designer owns user experience. These are com
 - When Designer proposes an interaction pattern, Architect evaluates feasibility
 - In conflict: Architect says "technically impossible" → Designer proposes alternative pattern; Designer says "this will confuse users" → Architect must listen
 
-## Collaboration with Engineer and QA
+## Collaboration with Engineer and Tester
 When engineer is implementing UI:
 - Provide specific, concrete interaction guidance
 - Clarify ambiguous design intent before implementation begins
 - Review implemented work from UX perspective when complete
 
-When QA tests:
-- Advise on what good UX behavior looks like so QA can validate against the right standard
+When tester tests:
+- Advise on what good UX behavior looks like so tester can validate against the right standard
 
 ## User Scenario Analysis Process
 When evaluating a feature or design, follow this sequence:

--- a/agents/reviewer.md
+++ b/agents/reviewer.md
@@ -36,7 +36,7 @@ You review non-code deliverables:
 - Research summaries and synthesis documents
 - Technical documentation for non-technical audiences
 
-**QA handles**: bun test, tsc --noEmit, code correctness, security review
+**Tester handles**: bun test, tsc --noEmit, code correctness, security review
 **You handle**: factual accuracy, citation integrity, internal consistency, grammar/format
 
 ## Verification Checklist


### PR DESCRIPTION
## Summary

Normalize terminology in agent role references: `QA`/`qa` → `Tester`/`tester` across 3 agent markdown files (architect, designer, reviewer). Terminology-only rename — no behavior, schema, or tool invocation changes.

## Why

**Prerequisite for nexus-core bootstrap import** — this is W4 from the nexus-core `plan session #2`, Issue #5 (import-from-claude-nexus). The rename ensures that the first `@moreih29/nexus-core` release imports a pristine, terminology-consistent source from `claude-nexus`, matching the already-normalized convention used in `opencode-nexus/src/agents/prompts.ts`.

## Changes

- \`agents/designer.md\` — 4 occurrences (collaboration support, section heading, test-time advice)
- \`agents/architect.md\` — 3 occurrences (technical escalation support, section heading, systemic issue escalation)
- \`agents/reviewer.md\` — 1 occurrence (responsibility boundary with tester)

Total: 8 insertions / 8 deletions across 3 files.

## Test plan

- [x] \`grep -r 'qa\\|QA' agents/\` returns no matches in role-related context
- [ ] Merge this PR
- [ ] nexus-core bootstrap import via \`bun run scripts/import-from-claude-nexus.ts --apply\` (performed in nexus-core repo after merge)
- [ ] verify imported agents/architect/body.md and agents/designer/body.md contain 'tester' in the rewritten sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)