### PR TITLE
feat: adopt nexus-core v0.19.0 — nx_plan_decide decision-only (v0.31.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "claude-nexus",
       "description": "Claude Code plugin for nexus-core agent orchestration",
-      "version": "0.30.1",
+      "version": "0.31.0",
       "author": {
         "name": "kih"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": {
     "name": "kih"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## [0.31.0] - 2026-04-22
+
+### Changed
+
+- `@moreih29/nexus-core` **v0.18.2 → v0.19.0** 채택 (upstream PR #56, "fix(plan): make nx_plan_decide decision-only"). MCP 번들(`dist/mcp/server.js`)과 sync 산출물(`skills/nx-plan/SKILL.md`, `skills/nx-auto-plan/SKILL.md`) Step 5 가이드가 새 계약에 맞춰 갱신됨.
+
+### Breaking (upstream MCP contract passthrough)
+
+- `nx_plan_decide` input 스키마에서 `how_agents` / `how_summary` / `how_agent_ids` 3개 필드 제거. 최종 결정 텍스트·상태만 저장하며 `issue.analysis`는 변형하지 않음.
+- `issue.analysis`는 이제 **append-only** — HOW 기여 기록은 오직 `nx_plan_analysis_add(issue_id, role, agent_id?, summary)`를 통해 Step 4에서 쌓아야 함. Step 7 task 분해는 그 누적 기록을 참조.
+
+### Consumer Action Required
+
+- MCP 도구를 **직접** 호출해 `nx_plan_decide`에 `how_*` 필드를 넣고 있던 외부 소비자는 해당 필드를 제거해야 함. Lead 최종 synthesis는 `decision` 필드로만 전달.
+- HOW 분석은 계속 `nx_plan_analysis_add`로 기록 유지. 사후에 HOW를 추가 실행해야 하면 재spawn/resume 후 analysis 엔트리를 새로 append.
+- Nexus 스킬(`[plan]` / `[auto-plan]`)을 정상 경로로 사용하는 경우에는 사용자측 조치 없음 — 갱신된 SKILL 가이드가 자동으로 새 계약을 준수.
+
 ## [0.30.1] - 2026-04-22
 
 ### Fixed

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "claude-nexus",
       "devDependencies": {
-        "@moreih29/nexus-core": "^0.18.2",
+        "@moreih29/nexus-core": "^0.19.0",
         "@types/bun": "^1.3.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",
@@ -17,7 +17,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@moreih29/nexus-core": ["@moreih29/nexus-core@0.18.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0", "yaml": "^2.8.1", "zod": "^4.1.8" }, "bin": { "nexus-mcp": "dist/mcp/server.js", "nexus-sync": "dist/cli/sync.js" } }, "sha512-mpjr7wY2xkpYcXAIkd4em6O9j8n4PeZw49UH55BNFvUls1dTvJQJIHSzCRLD3A5l7hVNFR/kC8YpfVXRdL3XUg=="],
+    "@moreih29/nexus-core": ["@moreih29/nexus-core@0.19.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0", "yaml": "^2.8.1", "zod": "^4.1.8" }, "bin": { "nexus-mcp": "dist/mcp/server.js", "nexus-sync": "dist/cli/sync.js" } }, "sha512-Bljpviq251W57TCxlnpJDYDmNG8VOfFSocWOcESEYOgLbLbplt8wT1rOPeDplSjkaC6VpVu8N8JORmpjhERGcw=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 

--- a/dist/mcp/server.js
+++ b/dist/mcp/server.js
@@ -3,25 +3,43 @@ var __getProtoOf = Object.getPrototypeOf;
 var __defProp = Object.defineProperty;
 var __getOwnPropNames = Object.getOwnPropertyNames;
 var __hasOwnProp = Object.prototype.hasOwnProperty;
+function __accessProp(key) {
+  return this[key];
+}
+var __toESMCache_node;
+var __toESMCache_esm;
 var __toESM = (mod, isNodeMode, target) => {
+  var canCache = mod != null && typeof mod === "object";
+  if (canCache) {
+    var cache = isNodeMode ? __toESMCache_node ??= new WeakMap : __toESMCache_esm ??= new WeakMap;
+    var cached = cache.get(mod);
+    if (cached)
+      return cached;
+  }
   target = mod != null ? __create(__getProtoOf(mod)) : {};
   const to = isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target;
   for (let key of __getOwnPropNames(mod))
     if (!__hasOwnProp.call(to, key))
       __defProp(to, key, {
-        get: () => mod[key],
+        get: __accessProp.bind(mod, key),
         enumerable: true
       });
+  if (canCache)
+    cache.set(mod, to);
   return to;
 };
 var __commonJS = (cb, mod) => () => (mod || cb((mod = { exports: {} }).exports, mod), mod.exports);
+var __returnValue = (v) => v;
+function __exportSetter(name, newValue) {
+  this[name] = __returnValue.bind(null, newValue);
+}
 var __export = (target, all) => {
   for (var name in all)
     __defProp(target, name, {
       get: all[name],
       enumerable: true,
       configurable: true,
-      set: (newValue) => all[name] = () => newValue
+      set: __exportSetter.bind(all, name)
     });
 };
 
@@ -20175,13 +20193,10 @@ var planUpdateTool = {
 var planDecideTool = {
   group: "plan",
   name: "nx_plan_decide",
-  description: "Record a decision for a plan issue",
+  description: "Record the final decision for a plan issue",
   inputSchema: {
     issue_id: numberType().describe("Issue ID to decide"),
-    decision: stringType().describe("Decision text"),
-    how_agents: arrayType(stringType()).optional().describe("Names of HOW agents that contributed analysis"),
-    how_summary: recordType(stringType(), stringType()).optional().describe("Summary of each agent's key input"),
-    how_agent_ids: recordType(stringType(), stringType()).optional().describe("Mapping from agent name to agent ID")
+    decision: stringType().describe("Decision text")
   }
 };
 var planResumeTool = {
@@ -20382,7 +20397,7 @@ var planToolBindings = [
   },
   {
     definition: planDecideTool,
-    handler: async ({ issue_id, decision, how_agents, how_summary, how_agent_ids }) => {
+    handler: async ({ issue_id, decision }) => {
       const pPath = planPath();
       let responsePayload = {};
       await updateJsonFileLocked(pPath, null, (raw) => {
@@ -20398,23 +20413,6 @@ var planToolBindings = [
         }
         issue2.status = "decided";
         issue2.decision = decision;
-        if (how_agents && how_agents.length > 0) {
-          const now = new Date().toISOString();
-          if (!issue2.analysis) {
-            issue2.analysis = [];
-          }
-          for (const agentName of how_agents) {
-            const entry = {
-              role: agentName,
-              summary: how_summary?.[agentName] ?? "",
-              recorded_at: now
-            };
-            if (how_agent_ids?.[agentName]) {
-              entry.agent_id = how_agent_ids[agentName];
-            }
-            issue2.analysis.push(entry);
-          }
-        }
         const allComplete = raw.issues.every((candidate) => candidate.status === "decided");
         const remaining = raw.issues.filter((candidate) => candidate.status !== "decided");
         responsePayload = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.30.1",
+  "version": "0.31.0",
   "type": "module",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": "kih",
@@ -41,7 +41,7 @@
     "settings.json"
   ],
   "devDependencies": {
-    "@moreih29/nexus-core": "^0.18.2",
+    "@moreih29/nexus-core": "^0.19.0",
     "@types/bun": "^1.3.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.6.0"

--- a/skills/nx-auto-plan/SKILL.md
+++ b/skills/nx-auto-plan/SKILL.md
@@ -96,7 +96,7 @@ Use `nx_plan_decide` to mark the issue as decided. The decision text MUST includ
 - The selected approach and its rationale
 - The rejected alternatives and their dismissal reasons
 
-If HOW subagents participated in the issue, bundle their contribution information so it can be referenced in future resumes and Step 7 task decomposition.
+`nx_plan_decide` records only the final decision text and decision state — it does **not** append to `analysis`. If HOW subagents participated, their analysis and resume-routing records must already have been written via `nx_plan_analysis_add` in Step 4, and Step 7 should reference those records directly.
 
 If the decision creates follow-up questions or derived issues, add them with `nx_plan_update` and move to Step 6. Do not ask the user for confirmation.
 

--- a/skills/nx-plan/SKILL.md
+++ b/skills/nx-plan/SKILL.md
@@ -111,7 +111,7 @@ Issues must be processed one at a time. For each issue:
 
 ### Step 5: Record Decision
 
-When a decision is reached, use `nx_plan_decide` to mark the issue as decided. If HOW subagents participated in the issue, bundle their contribution information so it can be referenced in future resumes and Step 7 task decomposition.
+When a decision is reached, use `nx_plan_decide` to mark the issue as decided. `nx_plan_decide` records only the final decision text and decision state — it does **not** add to `analysis`. All HOW analysis and resume routing records must already be stored via `nx_plan_analysis_add` in Step 4.
 
 - Immediately after recording, check overall progress with `nx_plan_status` and announce the next issue in one line.
 - Check whether new follow-up questions have emerged, and if so, add follow-up issues with `nx_plan_update`.


### PR DESCRIPTION
## Summary
- `@moreih29/nexus-core` v0.18.2 → v0.19.0 채택. upstream PR [moreih29/nexus-core#56](https://github.com/moreih29/nexus-core/pull/56).
- `nx_plan_decide` input 스키마에서 `how_agents` / `how_summary` / `how_agent_ids` 제거 — 최종 결정만 저장, `issue.analysis` 변형 금지.
- `issue.analysis`는 append-only로 고정되어 `nx_plan_analysis_add`로만 기록.
- Sync 결과 `skills/nx-plan/SKILL.md` / `skills/nx-auto-plan/SKILL.md` Step 5 가이드가 새 계약을 반영하게 갱신됨.
- MCP 번들(`dist/mcp/server.js`) 재빌드.

## Consumer impact
- MCP 도구를 직접 호출하던 외부 소비자는 `how_*` 필드 제거 필요.
- Nexus 스킬(`[plan]` / `[auto-plan]`) 정상 경로 사용자는 조치 없음 — 갱신된 SKILL 가이드가 자동 반영.

## Version
v0.30.1 → **v0.31.0** (minor, upstream breaking MCP 계약 passthrough). package.json + `.claude-plugin/plugin.json` + `.claude-plugin/marketplace.json` 세 곳 동기 완료.

## Test plan
- [x] `bun run clean && bun install --frozen-lockfile`
- [x] `bun run build` — 실패 없음
- [x] `bun run typecheck` — 실패 없음
- [x] `bun run test` — e2e 전부 `ok`
- [x] clean rebuild 후 `git status`가 수렴

🤖 Generated with [Claude Code](https://claude.com/claude-code)