### PR TITLE
fix: move MCP declaration into plugin.json (v0.31.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "claude-nexus",
       "description": "Claude Code plugin for nexus-core agent orchestration",
-      "version": "0.31.0",
+      "version": "0.31.1",
       "author": {
         "name": "kih"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": {
     "name": "kih"
@@ -13,5 +13,11 @@
     "plugin",
     "nexus",
     "agent-orchestration"
-  ]
+  ],
+  "mcpServers": {
+    "nexus-core": {
+      "command": "node",
+      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/mcp/server.js"]
+    }
+  }
 }

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-  "mcpServers": {
-    "nexus-core": {
-      "command": "node",
-      "args": ["${CLAUDE_PLUGIN_ROOT}/dist/mcp/server.js"]
-    }
-  }
-}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.31.1] - 2026-04-22
+
+### Fixed
+
+- 플러그인 MCP 서버가 같은 이름(`nexus-core`)으로 **이중 등록**되어 `/mcp`에서 "Failed to reconnect to nexus-core"가 반복되던 문제. 원인은 플러그인 루트의 `.mcp.json`이 (1) 플러그인 manifest로 로드되는 경로와 (2) cwd가 플러그인 레포일 때 project-scoped MCP로도 로드되는 경로에서 동시에 읽혔기 때문. project-scoped 경로는 `${CLAUDE_PLUGIN_ROOT}` 변수를 치환하지 않아 `MODULE_NOT_FOUND`로 실패하며 재시도를 누적시킴. MCP 선언을 `.claude-plugin/plugin.json`의 인라인 `mcpServers` 필드로 이전하고 루트 `.mcp.json`을 제거해 이중 로드 경로 자체를 제거.
+
 ## [0.31.0] - 2026-04-22
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.31.0",
+  "version": "0.31.1",
   "type": "module",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": "kih",
@@ -37,7 +37,6 @@
     "dist",
     "scripts",
     ".claude-plugin",
-    ".mcp.json",
     "settings.json"
   ],
   "devDependencies": {

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -14,7 +14,6 @@ echo "[1/5] plugin shape"
 for f in \
   .claude-plugin/plugin.json \
   .claude-plugin/marketplace.json \
-  .mcp.json \
   hooks/hooks.json \
   settings.json \
   dist/mcp/server.js \
@@ -22,6 +21,10 @@ for f in \
   dist/hooks/prompt-router.js ; do
   [ -f "$f" ] && pass "$f" || fail "$f missing"
 done
+
+node -e "const p=require('./.claude-plugin/plugin.json');if(!p.mcpServers||!p.mcpServers['nexus-core'])process.exit(1)" \
+  && pass ".claude-plugin/plugin.json declares mcpServers.nexus-core" \
+  || fail ".claude-plugin/plugin.json missing mcpServers.nexus-core"
 
 for dir_name in architect designer engineer lead postdoc researcher reviewer strategist tester writer ; do
   [ -f "agents/${dir_name}.md" ] && pass "agents/${dir_name}.md" || fail "agents/${dir_name}.md missing"


### PR DESCRIPTION
## Summary

- 플러그인 루트의 `.mcp.json`이 플러그인 manifest와 project-scoped MCP로 **이중 로드**되어 `nexus-core`가 두 번 등록되던 버그 수정. project-scoped 경로에서는 `${CLAUDE_PLUGIN_ROOT}`가 치환되지 않아 `MODULE_NOT_FOUND`로 연결이 반복 실패했다.
- MCP 서버 선언을 `.claude-plugin/plugin.json`의 인라인 `mcpServers` 필드로 이전. 루트 `.mcp.json` 제거로 이중 로드 경로 자체가 사라짐.
- v0.31.1 release — consumer action 없음 (정상 설치 경로에서 동작 동일, 에러만 사라짐).

## Root cause

플러그인 dogfooding 세션(cwd = 플러그인 레포)에서 MCP 로그 분석:

```
# mcp-logs-nexus-core (project-scoped, 실패)
Error: Cannot find module '/Users/.../claude-nexus/${CLAUDE_PLUGIN_ROOT}/dist/mcp/server.js'

# mcp-logs-plugin-claude-nexus-nexus-core (플러그인, 성공)
Successfully connected (transport: stdio)
```

Claude Code 공식 문서([plugins-reference](https://code.claude.com/docs/en/plugins-reference))에 따르면 `plugin.json`의 `mcpServers` 필드에 인라인 선언이 공식 지원되며 `${CLAUDE_PLUGIN_ROOT}`는 플러그인 시스템 컨텍스트에서만 치환된다. 루트 `.mcp.json`을 제거하고 인라인으로 이전하는 것이 이중 로드를 구조적으로 제거하는 공식 경로.

## Test plan

- [x] `bun run clean && bun install --frozen-lockfile`
- [x] `bun run build` — 통과
- [x] `bun run typecheck` — 통과
- [x] `bun run test` — e2e 전체 통과 (`.mcp.json` 체크를 `plugin.json`의 `mcpServers.nexus-core` 체크로 교체)
- [x] 재빌드 후 `git status` clean — 산출물 이미 수렴
- [ ] 병합 후 `/plugin update claude-nexus` → `/mcp` nexus-core 단일 등록 확인
- [ ] 병합 후 기존 설치본에서 `nx_plan_start` 같은 MCP 도구 호출 smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)