### PR TITLE
fix: adopt nexus-core v0.19.1 — plan resume guidance UUID-only (v0.31.2)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "claude-nexus",
       "description": "Claude Code plugin for nexus-core agent orchestration",
-      "version": "0.31.1",
+      "version": "0.31.2",
       "author": {
         "name": "kih"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": {
     "name": "kih"

--- a/.nexus/memory/pattern-issue-triage-upstream-vs-local.md
+++ b/.nexus/memory/pattern-issue-triage-upstream-vs-local.md
@@ -1,0 +1,33 @@
+# 이슈 트리아지: upstream(nexus-core) vs local(claude-nexus)
+
+**원칙**: 문제가 발생하면 **원인을 먼저 확정**한 뒤, 소스에 따라 처리 경로를 나눈다.
+
+## 판단 기준
+
+| 원인 위치 | 처리 |
+|---|---|
+| `@moreih29/nexus-core` canonical(스킬 본문, 에이전트 본문, MCP 도구 계약, vocabulary) | **nexus-core 리포에 이슈 등록** — `gh issue create -R moreih29/nexus-core …`. 여기서 직접 수정 금지. sync로만 수용. |
+| claude-nexus 자체(플러그인 shell, hook 런타임, 빌드 파이프라인, `.claude-plugin/*`, `dist/*` 래핑, `test/e2e.sh`, 프로젝트 문서, `.nexus/`) | **직접 수정 + 커밋**. |
+| 양쪽 걸침(예: canonical 계약 변경을 이 플러그인이 먼저 요구) | nexus-core 이슈로 제안 먼저 → 수용되면 sync로 반영. 우회가 급하면 플러그인 내부에 **임시 주석**과 함께 shim, 단 canonical 복구 시 제거 의무. |
+
+## 원인 확정 절차 (흔한 함정 회피)
+
+1. 증상이 나타난 파일의 **provenance**를 먼저 확인한다:
+   - 스킬/에이전트/MCP 본문에 문제가 있으면 `git log`로 해당 파일이 sync 산출물인지 로컬 작성물인지 본다. sync 산출물이면 upstream.
+   - `skills/*/SKILL.md`, `agents/*.md` (lead 제외), `dist/mcp/*` → 대부분 nexus-core sync 결과물.
+   - `agents/lead.md`, `.claude-plugin/*`, `hooks/*`, `scripts/*`, `test/*`, `README*`, `CHANGELOG.md`, `.nexus/*` → 로컬.
+2. v0.27.0 같은 과거 버전에서 동작했던 기능이 현재 깨졌다면 `git show v0.27.0:<path>`로 **diff 근거**를 확보한 뒤 이슈 본문에 인용한다.
+3. Claude Code 하네스 자체의 도구 설명과 실제 동작이 엇갈리는 경우가 있다(예: SendMessage `never by UUID` 문구 vs 실측). 실측을 우선 신뢰하되, 이슈 본문에 두 소스를 모두 제시한다.
+
+## 이슈 본문 구성(nexus-core로 올릴 때)
+
+- **Summary** — 증상 한 단락.
+- **Where** — 정확한 파일/라인 + 문제 문구 인용.
+- **Empirical evidence** — 재현 표, 환경 전제(예: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`).
+- **Impact** — 다운스트림 스킬/경로가 어떻게 조용히 실패하는지.
+- **Suggested fix** — 최소 침습 수정안. 선택적으로 한 줄 주석 제안.
+- 영어로 작성(nexus-core 컨벤션).
+
+## 선례
+
+- 2026-04-22: `skills/nx-plan/SKILL.md` Step 4.3의 `(or the name the Lead assigned)` 문구가 Lead에게 `SendMessage` resume 대상으로 name 저장을 유도해 resume이 조용히 실패하던 문제. v0.27.0 empirical 메모리에 기록된 UUID-only 규칙과 상충. 플러그인 로컬 수정 금지(스킬은 sync 산출물), nexus-core 이슈 #58로 등록.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.31.2] - 2026-04-22
+
+### Changed
+
+- `@moreih29/nexus-core` **v0.19.0 → v0.19.1** 채택 (upstream PR #61, "fix(plan): require spawn agent id for resume records"). claude-nexus 이슈 #58 upstream 반영분. Lead가 종료된 서브에이전트를 resume할 때 `SendMessage({ to: <name> })`는 동작하지 않고 spawn 도구가 반환한 agent id(UUID) 필수라는 실측을 canonical 가이드가 명확히 반영. 영향받은 sync 산출물: `agents/lead.md`, `skills/nx-plan/SKILL.md`, `skills/nx-auto-plan/SKILL.md`. upstream PR #60(opencode skill frontmatter)·PR #62(codex nx launcher)는 다른 하네스 대상이라 본 플러그인에 영향 없음.
+
 ## [0.31.1] - 2026-04-22
 
 ### Fixed

--- a/agents/lead.md
+++ b/agents/lead.md
@@ -262,7 +262,7 @@ For questions that can be answered briefly, answer directly without structure.
 
 ### Subagent ID Recording Practice
 
-Every time a subagent is spawned, record its id (either returned by the harness spawn tool or the `name` the Lead assigned) through one of the paths below. Without this, `nx_plan_resume` / `nx_task_resume` will have no resume candidates to return.
+Every time a subagent is spawned, record the agent id returned by the harness spawn tool through one of the paths below. Do not substitute a human-readable assigned name; names are for active-session messaging only and are not a safe resume identifier for completed sessions. Without this, `nx_plan_resume` / `nx_task_resume` will have no resume candidates to return.
 
 - HOW participation → pass `agent_id` to `nx_plan_analysis_add(issue_id, role, agent_id=<id>, summary)` (Step 4 of nx-plan / nx-auto-plan skill).
 - Task execution → store via `nx_task_update(id, owner={role, agent_id=<id>, resume_tier=<ephemeral|bounded|persistent>})` (Step 2 of nx-run skill).

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "claude-nexus",
       "devDependencies": {
-        "@moreih29/nexus-core": "^0.19.0",
+        "@moreih29/nexus-core": "^0.19.1",
         "@types/bun": "^1.3.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",
@@ -17,7 +17,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@moreih29/nexus-core": ["@moreih29/nexus-core@0.19.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0", "yaml": "^2.8.1", "zod": "^4.1.8" }, "bin": { "nexus-mcp": "dist/mcp/server.js", "nexus-sync": "dist/cli/sync.js" } }, "sha512-Bljpviq251W57TCxlnpJDYDmNG8VOfFSocWOcESEYOgLbLbplt8wT1rOPeDplSjkaC6VpVu8N8JORmpjhERGcw=="],
+    "@moreih29/nexus-core": ["@moreih29/nexus-core@0.19.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0", "yaml": "^2.8.1", "zod": "^4.1.8" }, "bin": { "nexus-mcp": "dist/mcp/server.js", "nexus-sync": "dist/cli/sync.js" } }, "sha512-PIk7I1huN72fJs6ePY1/WIWWwyIaNsbGxp9zH5SSSmGUjqRFm9uDh14upp4j1Jf3DjMNDsojqXUuV8kqGSy7Fw=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.31.1",
+  "version": "0.31.2",
   "type": "module",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": "kih",
@@ -40,7 +40,7 @@
     "settings.json"
   ],
   "devDependencies": {
-    "@moreih29/nexus-core": "^0.19.0",
+    "@moreih29/nexus-core": "^0.19.1",
     "@types/bun": "^1.3.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.6.0"

--- a/skills/nx-auto-plan/SKILL.md
+++ b/skills/nx-auto-plan/SKILL.md
@@ -72,7 +72,7 @@ Issues must be processed one at a time. For each issue:
 2. If needed, spawn HOW subagents for independent analysis.
    - If reusing context from a prior HOW session for the same role is advantageous, check resume routing information with `nx_plan_resume` first.
    - If resumable, continue with the existing session; otherwise, spawn fresh.
-3. When HOW results return, record them on the issue with `nx_plan_analysis_add(issue_id, role, agent_id=<id from spawn>, summary)`. The `agent_id` is the value `nx_plan_resume` will return on a future resume request for the same role, so always pass it.
+3. When HOW results return, record them on the issue with `nx_plan_analysis_add(issue_id, role, agent_id=<id from spawn>, summary)`. The `agent_id` is the value `nx_plan_resume` will return on a future resume request for the same role, so always pass the agent id obtained from the spawn tool response. Do not substitute a human-readable assigned name; names are only for messaging a currently running subagent and are not a safe resume identifier for a completed session.
 4. **Lead internal deliberation**: enumerate candidate options, compare pros/cons and trade-offs, and select the most reasonable one. Do not output comparison tables or option presentations.
 5. Proceed immediately to Step 5 to record the decision.
 

--- a/skills/nx-plan/SKILL.md
+++ b/skills/nx-plan/SKILL.md
@@ -73,7 +73,7 @@ Issues must be processed one at a time. For each issue:
 2. If needed, spawn HOW subagents for independent analysis.
    - If reusing context from a prior HOW session for the same role is advantageous, check resume routing information with `nx_plan_resume` first.
    - If resumable, continue with the existing session; otherwise, spawn fresh.
-3. When HOW results return, record them on the issue with `nx_plan_analysis_add(issue_id, role, agent_id=<id from spawn>, summary)`. The `agent_id` is the value `nx_plan_resume` will return on a future resume request for the same role, so always pass the id obtained from the spawn tool response (or the name the Lead assigned). This record feeds both future resume paths and Step 7 task decomposition.
+3. When HOW results return, record them on the issue with `nx_plan_analysis_add(issue_id, role, agent_id=<id from spawn>, summary)`. The `agent_id` is the value `nx_plan_resume` will return on a future resume request for the same role, so always pass the agent id obtained from the spawn tool response. Do not substitute a human-readable assigned name; names are only for messaging a currently running subagent and are not a safe resume identifier for a completed session. This record feeds both future resume paths and Step 7 task decomposition.
 4. After synthesis, present a comparison table and recommendation.
 5. Receive the user's response and record the decision.
 


### PR DESCRIPTION
## Summary
- Adopt `@moreih29/nexus-core` v0.19.0 → v0.19.1. upstream PR moreih29/nexus-core#61 resolves claude-nexus #58: plan / auto-plan / lead guidance no longer treats the human-readable assigned `name` as interchangeable with the spawn-returned agent id — `SendMessage` resume of a completed subagent requires the UUID.
- Refreshed sync output: `agents/lead.md`, `skills/nx-plan/SKILL.md`, `skills/nx-auto-plan/SKILL.md`. Version bump v0.31.1 → v0.31.2 across the three version files + CHANGELOG entry.
- Adds `.nexus/memory/pattern-issue-triage-upstream-vs-local.md` capturing the upstream-vs-local triage pattern observed during this cycle so the next similar diagnosis reuses the same decision axis.

## Why
Completed-session resume paths silently fell back to fresh spawn when Lead stored the assigned `name` as `agent_id`, defeating the `persistent` / `bounded` resume-tier reuse. The upstream wording ambiguity was filed as nexus-core #58 and fixed in PR #61. The other two v0.19.1 fixes (opencode frontmatter, codex `nx` launcher) target other harnesses and do not affect this plugin.

## Test plan
- [x] `bun run clean && bun run build` — sync + bundle regenerated, 13/13 harness files written
- [x] `bun run typecheck` — tsc green
- [x] `bun run test` — all e2e checks pass
- [x] `git status` clean after rebuild (no drift)
- [ ] After merge: tag `v0.31.2`, confirm `Publish` workflow green, `gh release create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)