### PR TITLE
fix: adopt nexus-core v0.19.2 — explicit resume macro in plan skills (v0.31.3)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "claude-nexus",
       "description": "Claude Code plugin for nexus-core agent orchestration",
-      "version": "0.31.2",
+      "version": "0.31.3",
       "author": {
         "name": "kih"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": {
     "name": "kih"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.31.3] - 2026-04-22
+
+### Changed
+
+- `@moreih29/nexus-core` **v0.19.1 → v0.19.2** 채택 (upstream PR #65, "fix(plan): make resume macro explicit in planning skills"). `nx-plan` / `nx-auto-plan` Step 4.2에서 resume 분기가 자연어 "continue with the existing session"에서 하네스 구체 매크로 `SendMessage({ to: "<id>", message: "<resume prompt>" })`로 교체. Lead가 resume 경로를 고를 때 실제 호출 형태를 문서가 직접 보여주므로 `name` 혼동의 두 번째 경로도 차단됨. 영향받은 sync 산출물: `skills/nx-plan/SKILL.md`, `skills/nx-auto-plan/SKILL.md`.
+
 ## [0.31.2] - 2026-04-22
 
 ### Changed

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "claude-nexus",
       "devDependencies": {
-        "@moreih29/nexus-core": "^0.19.1",
+        "@moreih29/nexus-core": "^0.19.2",
         "@types/bun": "^1.3.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",
@@ -17,7 +17,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@moreih29/nexus-core": ["@moreih29/nexus-core@0.19.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0", "yaml": "^2.8.1", "zod": "^4.1.8" }, "bin": { "nexus-mcp": "dist/mcp/server.js", "nexus-sync": "dist/cli/sync.js" } }, "sha512-PIk7I1huN72fJs6ePY1/WIWWwyIaNsbGxp9zH5SSSmGUjqRFm9uDh14upp4j1Jf3DjMNDsojqXUuV8kqGSy7Fw=="],
+    "@moreih29/nexus-core": ["@moreih29/nexus-core@0.19.2", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0", "yaml": "^2.8.1", "zod": "^4.1.8" }, "bin": { "nexus-mcp": "dist/mcp/server.js", "nexus-sync": "dist/cli/sync.js" } }, "sha512-8JViq9P50SPDMVArBukCmQa7VmxBmdhKxtpJ9O5HM0K3OHtVV712Naw0di/d8mhp6tPweqibPtiZEhkeZKBbGQ=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.31.2",
+  "version": "0.31.3",
   "type": "module",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": "kih",
@@ -40,7 +40,7 @@
     "settings.json"
   ],
   "devDependencies": {
-    "@moreih29/nexus-core": "^0.19.1",
+    "@moreih29/nexus-core": "^0.19.2",
     "@types/bun": "^1.3.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.6.0"

--- a/skills/nx-auto-plan/SKILL.md
+++ b/skills/nx-auto-plan/SKILL.md
@@ -71,7 +71,7 @@ Issues must be processed one at a time. For each issue:
 1. Lead summarizes the current state and the problem.
 2. If needed, spawn HOW subagents for independent analysis.
    - If reusing context from a prior HOW session for the same role is advantageous, check resume routing information with `nx_plan_resume` first.
-   - If resumable, continue with the existing session; otherwise, spawn fresh.
+   - If resumable, invoke `SendMessage({ to: "<id>", message: "<resume prompt>" })` with the `agent_id` returned by `nx_plan_resume`; otherwise, spawn fresh.
 3. When HOW results return, record them on the issue with `nx_plan_analysis_add(issue_id, role, agent_id=<id from spawn>, summary)`. The `agent_id` is the value `nx_plan_resume` will return on a future resume request for the same role, so always pass the agent id obtained from the spawn tool response. Do not substitute a human-readable assigned name; names are only for messaging a currently running subagent and are not a safe resume identifier for a completed session.
 4. **Lead internal deliberation**: enumerate candidate options, compare pros/cons and trade-offs, and select the most reasonable one. Do not output comparison tables or option presentations.
 5. Proceed immediately to Step 5 to record the decision.

--- a/skills/nx-plan/SKILL.md
+++ b/skills/nx-plan/SKILL.md
@@ -72,7 +72,7 @@ Issues must be processed one at a time. For each issue:
 1. Lead summarizes the current state and the problem.
 2. If needed, spawn HOW subagents for independent analysis.
    - If reusing context from a prior HOW session for the same role is advantageous, check resume routing information with `nx_plan_resume` first.
-   - If resumable, continue with the existing session; otherwise, spawn fresh.
+   - If resumable, invoke `SendMessage({ to: "<id>", message: "<resume prompt>" })` with the `agent_id` returned by `nx_plan_resume`; otherwise, spawn fresh.
 3. When HOW results return, record them on the issue with `nx_plan_analysis_add(issue_id, role, agent_id=<id from spawn>, summary)`. The `agent_id` is the value `nx_plan_resume` will return on a future resume request for the same role, so always pass the agent id obtained from the spawn tool response. Do not substitute a human-readable assigned name; names are only for messaging a currently running subagent and are not a safe resume identifier for a completed session. This record feeds both future resume paths and Step 7 task decomposition.
 4. After synthesis, present a comparison table and recommendation.
 5. Receive the user's response and record the decision.


### PR DESCRIPTION
## Summary
- Adopt `@moreih29/nexus-core` v0.19.1 → v0.19.2. upstream PR moreih29/nexus-core#65 replaces the natural-language "continue with the existing session" clause in `nx-plan` / `nx-auto-plan` Step 4.2 with the concrete harness macro `SendMessage({ to: "<id>", message: "<resume prompt>" })`.
- Together with v0.19.1's UUID-only identifier wording (shipped in v0.31.2), the planning-skill resume path now shows Lead the exact call shape, closing the remaining avenue where a human-readable `name` could have been substituted by accident.
- Version bump v0.31.2 → v0.31.3 across the three version files + CHANGELOG entry.

## Why
Prior wording left the resume invocation implicit, so even with UUID-only storage the call site could still be mis-rendered at the Lead level. Making the macro explicit removes that ambiguity entirely.

## Test plan
- [x] `bun run clean && bun run build` — sync + bundle regenerated
- [x] `bun run typecheck` — tsc green
- [x] `bun run test` — all e2e checks pass
- [x] `git status` clean after rebuild
- [ ] After merge: tag `v0.31.3`, confirm `Publish` workflow, `gh release create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)