### PR TITLE
fix: namespace agent to claude-nexus:lead so main thread adopts Lead spec (v0.32.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "claude-nexus",
       "description": "Claude Code plugin for nexus-core agent orchestration",
-      "version": "0.32.0",
+      "version": "0.32.1",
       "author": {
         "name": "kih"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": {
     "name": "kih"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - 사용자 조치 불필요. 플러그인 업데이트만 받으면 다음 신규 세션부터 자동 적용.
 - 기존 0.32.0 사용자는 업데이트 전까지 메인 스레드에 Lead 명세가 주입되지 않는 상태.
 - `bun run sync` 재실행 시 `settings.json`이 덮어써지지 않음을 실측 확인(`wrote 0/13 files`, settings.json 무변동). nexus-sync의 스코프는 `agents/{id}.md`와 `skills/{id}/SKILL.md`에 한정.
+- `test/e2e.sh`에 회귀 방지 가드 2개 추가. (1) `settings.json`의 `agent` 값이 `<plugin-name>:<id>` 네임스페이스 형식을 따르는지, (2) 참조하는 agent 파일이 실재하는지 검증. 플러그인 이름 변경·agent 파일 부재 같은 silent fail을 CI에서 조기 차단.
 
 ## [0.32.0] - 2026-04-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.32.1] - 2026-04-24
+
+### Fixed
+
+- 플러그인 루트 `settings.json`의 `agent` 값을 `"lead"` → `"claude-nexus:lead"`로 교정. Claude Code의 플러그인 서브에이전트 참조 규칙이 `<plugin-name>:<agent-name>` 네임스페이스 형식을 요구하므로, bare name은 조용히 무시되어 메인 스레드가 Lead 시스템 프롬프트·도구 제약·모델 설정을 적용받지 못하고 있었음. 네임스페이스 형식으로 교정되면서 플러그인 활성화 시 사용자 대면 메인 스레드가 **Lead 서브에이전트로 시작**되어 `agents/lead.md`의 전체 명세(Role, Default Stance, `[Pre-check]` opening scaffold, Evidence Requirement 등)가 주입됨. nexus-core 쪽 변경 없음 — canonical spec은 harness-agnostic이고, 네임스페이스 prefix는 이 플러그인(claude-nexus)의 `.claude-plugin/plugin.json` name 필드에 귀속되므로 소비자 플러그인 레벨에서 해결하는 것이 구조적으로 맞음.
+
+### Notes
+
+- 사용자 조치 불필요. 플러그인 업데이트만 받으면 다음 신규 세션부터 자동 적용.
+- 기존 0.32.0 사용자는 업데이트 전까지 메인 스레드에 Lead 명세가 주입되지 않는 상태.
+- `bun run sync` 재실행 시 `settings.json`이 덮어써지지 않음을 실측 확인(`wrote 0/13 files`, settings.json 무변동). nexus-sync의 스코프는 `agents/{id}.md`와 `skills/{id}/SKILL.md`에 한정.
+
 ## [0.32.0] - 2026-04-23
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.32.0",
+  "version": "0.32.1",
   "type": "module",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": "kih",

--- a/settings.json
+++ b/settings.json
@@ -1,3 +1,3 @@
 {
-  "agent": "lead"
+  "agent": "claude-nexus:lead"
 }

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -26,6 +26,28 @@ node -e "const p=require('./.claude-plugin/plugin.json');if(!p.mcpServers||!p.mc
   && pass ".claude-plugin/plugin.json declares mcpServers.nexus-core" \
   || fail ".claude-plugin/plugin.json missing mcpServers.nexus-core"
 
+# settings.json agent must use <plugin-name>:<agent-id> namespace form
+# and point at an agent file that actually exists. Bare names are silently
+# ignored by Claude Code's plugin subagent resolver.
+agent_ref=$(node -p "require('./settings.json').agent || ''")
+plugin_name=$(node -p "require('./.claude-plugin/plugin.json').name")
+expected_prefix="${plugin_name}:"
+case "$agent_ref" in
+  "${expected_prefix}"*)
+    pass "settings.json agent uses ${expected_prefix}<id> namespace"
+    agent_id="${agent_ref#${expected_prefix}}"
+    [ -f "agents/${agent_id}.md" ] \
+      && pass "settings.json agent → agents/${agent_id}.md exists" \
+      || fail "settings.json agent → agents/${agent_id}.md missing"
+    ;;
+  "")
+    fail "settings.json has no agent field"
+    ;;
+  *)
+    fail "settings.json agent '$agent_ref' not namespaced with '${expected_prefix}' (bare names silently ignored)"
+    ;;
+esac
+
 for dir_name in architect designer engineer lead postdoc researcher reviewer strategist tester writer ; do
   [ -f "agents/${dir_name}.md" ] && pass "agents/${dir_name}.md" || fail "agents/${dir_name}.md missing"
 done


### PR DESCRIPTION
## Summary

- 플러그인 루트 `settings.json`의 `agent` 값을 bare name `"lead"`에서 네임스페이스 형식 `"claude-nexus:lead"`로 교정.
- Claude Code의 플러그인 서브에이전트 참조 규칙(`<plugin-name>:<agent-name>`)을 따르지 않으면 조용히 무시되어, 메인 스레드가 Lead 시스템 프롬프트·도구 제약·모델 설정을 적용받지 못하던 상태를 해결. 사용자 대면 메인 스레드가 이제 `agents/lead.md`의 전체 명세(Role, Default Stance, `[Pre-check]` opening scaffold, Evidence Requirement 등)로 시작됨.
- 구조적 판단: nexus-sync는 `agents/`와 `skills/`만 렌더링하고 `settings.json`을 건드리지 않음을 실측 확인(`wrote 0/13 files`). 네임스페이스 prefix는 이 플러그인의 `.claude-plugin/plugin.json` name 필드에 귀속되므로 **consumer 플러그인 레벨에서 종결**되며 nexus-core 변경 불필요.

## Changes

- `settings.json`: `"agent": "lead"` → `"agent": "claude-nexus:lead"`
- `package.json`, `.claude-plugin/plugin.json`: 0.32.0 → 0.32.1
- `CHANGELOG.md`: 0.32.1 엔트리 추가

## Test plan

- [x] `bun run typecheck` 통과
- [x] `bun run build` 성공 (MCP 서버·hooks·statusline 번들 재생성)
- [x] `bun run test` e2e 29개 체크 전부 통과
- [x] `bun run sync` 재실행 시 `settings.json` 무변동 확인 (`wrote 0/13 files`)
- [ ] 머지 후 새 Claude Code 세션을 열어 메인 스레드가 `[Pre-check]` scaffold로 응답 시작하는지 확인 (사용자 수동 검증)

🤖 Generated with [Claude Code](https://claude.com/claude-code)