### PR TITLE
feat: statusline cost tracking + CLAUDE_CONFIG_DIR isolation (v0.33.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "claude-nexus",
       "description": "Claude Code plugin for nexus-core agent orchestration",
-      "version": "0.32.1",
+      "version": "0.33.0",
       "author": {
         "name": "kih"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": {
     "name": "kih"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [0.33.0] - 2026-04-29
+
+### Added
+
+- **Statusline에서 `CLAUDE_CONFIG_DIR` 환경변수 분리 동작 지원.** Claude Code 본체가 `CLAUDE_CONFIG_DIR`을 통해 다중 OAuth 계정을 분리 저장하는 알고리즘과 동일하게 statusline도 동작. 미설정 시 기본 `~/.claude`, 설정 시 ① 캐시 경로(`.usage_cache`, `.nexus_version_cache`, `.api_cost_cache`)를 해당 디렉토리로 이동, ② macOS keychain service 이름을 `Claude Code-credentials-<sha256(NFC(envValue))[:8]>` 형태로 본체와 일치시켜 본체가 저장한 토큰을 정확히 조회, ③ Linux/Windows의 `${CLAUDE_CONFIG_DIR}/.credentials.json` 평문 파일 경로도 자동 분기. 두 OAuth 계정을 번갈아 띄워도 5h/7d 사용량과 캐시가 섞이지 않는다.
+
+- **API 모드(`ANTHROPIC_API_KEY` 설정) 사용자에게 오늘 비용 자동 표시.** 이전엔 `ANTHROPIC_ADMIN_KEY`를 별도 셋업한 소수만 활용 가능했고 그마저도 cost_report API의 query/response 변경으로 작동하지 않던 상태였음. 새 구현은 admin key 의존을 제거하고 로컬 jsonl 세션 로그(`${CLAUDE_CONFIG_DIR}/projects/<encoded-cwd>/<session>.jsonl`)를 직접 스캔해 오늘(UTC 자정 기준) 발생한 모든 assistant turn의 토큰을 모델별로 합산, Anthropic 공식 가격표 기반으로 USD 환산. statusline 라인 2에 `API $X.XX today` 형식으로 표시. 60s TTL 캐시 + mtime 필터로 매 렌더 비용은 < 100ms.
+
+### Changed
+
+- API 비용 표시 경로가 `cost_report` admin endpoint → 로컬 jsonl 스캔으로 전면 전환. `ANTHROPIC_ADMIN_KEY` 환경변수는 더 이상 사용되지 않는다(설정돼 있어도 무시됨, 에러 아님). 가격표는 `priceFor()` 함수 내부에 하드코딩되며 Opus 4 / 4.5+ / Sonnet 4.x / Haiku 4.5 / 구버전 deprecated 모델까지 패턴 매칭으로 18개 표준 모델 이름을 지원. cache_creation의 ephemeral 5m / 1h 분리 데이터를 우선 활용하고 없으면 안전한 5m 단가로 폴백.
+
+### Fixed
+
+- macOS keychain에서 Claude Code 본체가 저장한 토큰을 statusline이 못 찾던 문제. 이전엔 service 이름을 `"Claude Code-credentials"`로 하드코딩해서, `CLAUDE_CONFIG_DIR`로 띄운 세션의 OAuth 토큰 분리 저장(`-<hash>` suffix 형식)을 인식하지 못하고 항상 기본 계정 토큰만 읽었음. 본체와 동일 알고리즘으로 service 이름을 동적 생성해 정상화.
+
+### Notes
+
+- 사용자 조치 불필요. 플러그인 업데이트 후 다음 statusline 렌더부터 자동 적용.
+- 가격표는 maintenance burden — Anthropic이 새 모델을 출시하면 패치 릴리즈가 필요하다. 알 수 없는 모델은 합산에서 silent skip되어 비용이 약간 under-report되지만 over-report되진 않는 설계. 출처: <https://platform.claude.com/docs/en/about-claude/pricing> (2026-04 검증).
+- jsonl 포맷 의존: `~/.claude/projects/<encoded>/<session>.jsonl`은 Claude Code 내부 포맷이고 공식 stable API가 아니다. 본체가 포맷을 변경하면 statusline 비용 표시가 0이 되거나 누락될 수 있음. 다만 이 경로/포맷은 1년 이상 안정적이고 `ccusage` 등 광범위한 OSS 생태계가 의존하는 사실상 표준이라 위험은 낮다.
+- 미반영 가격 변형: web search ($10/1k searches), code execution session-runtime, fast mode 6×, data residency 1.1×, batch 50% 할인 — Claude Code 일반 사용 패턴에선 발생하지 않는 케이스라 의도적으로 단순화.
+- Windows에서 statusline 자체는 여전히 셸(`sh`/`curl`/`grep`/`sed`) 의존성이 남아 있어 WSL/Git Bash 없이는 동작하지 않는다(이번 릴리스 범위 밖).
+
 ## [0.32.1] - 2026-04-24
 
 ### Fixed

--- a/README.en.md
+++ b/README.en.md
@@ -51,7 +51,12 @@ With the plugin enabled, each new Claude Code session runs the `lead` agent as t
 
 ## Optional: statusline
 
-The plugin ships a two-line statusline script. Line one shows `◆Nexus vX.Y.Z`, the model, the project, and the git branch with staged/unstaged counts. Line two shows context-window usage plus 5-hour and 7-day Claude usage gauges with the time until each resets. The usage gauges require a Claude Pro or Max OAuth session; `~/.claude/.usage_cache` is shared across local sessions so concurrent Claude Code windows never re-fetch.
+The plugin ships a two-line statusline script. Line one shows `◆Nexus vX.Y.Z`, the model, the project, and the git branch with staged/unstaged counts. Line two shows context-window usage plus mode-specific information:
+
+- **OAuth session (Claude Pro / Max)** — 5-hour and 7-day Claude usage gauges with the time until each resets. `$CLAUDE_CONFIG_DIR/.usage_cache` (defaults to `~/.claude/.usage_cache`) is shared across local sessions so concurrent Claude Code windows never re-fetch.
+- **API mode (`ANTHROPIC_API_KEY` set)** — `API $X.XX today` showing the cost incurred today (UTC midnight boundary). Claude Code's local jsonl session logs are scanned directly to sum tokens per model and convert to USD using Anthropic's published pricing — no admin key setup required.
+
+When you use `CLAUDE_CONFIG_DIR` to separate multiple OAuth accounts, the statusline's cache path, keychain query, and cost scan all branch automatically using the same algorithm as Claude Code itself.
 
 Claude Code does not let a plugin auto-configure the user's `statusLine`, so register the `claude-nexus-statusline` CLI (shipped with the same npm package) from your own `~/.claude/settings.json`.
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ Claude Code 안에서 플러그인 마켓플레이스로 설치한다.
 
 ## 선택: statusline
 
-플러그인은 2줄 statusline 스크립트를 함께 배포한다. 첫 줄은 `◆Nexus vX.Y.Z`·모델·프로젝트·git 브랜치(staged/unstaged), 둘째 줄은 컨텍스트 사용률과 5h/7d 사용 한도 게이지(리셋까지 남은 시간). Claude Pro·Max OAuth 세션에서만 5h/7d가 표시되며, 로컬의 여러 Claude 세션이 `~/.claude/.usage_cache`를 공유하므로 API 중복 호출 없이 경합이 방지된다.
+플러그인은 2줄 statusline 스크립트를 함께 배포한다. 첫 줄은 `◆Nexus vX.Y.Z`·모델·프로젝트·git 브랜치(staged/unstaged), 둘째 줄은 컨텍스트 사용률과 모드별 사용량 정보:
+
+- **OAuth 세션 (Claude Pro·Max)** — 5h/7d 사용 한도 게이지(리셋까지 남은 시간). 로컬의 여러 Claude 세션이 `$CLAUDE_CONFIG_DIR/.usage_cache`(미설정 시 `~/.claude/.usage_cache`)를 공유하므로 API 중복 호출 없이 경합이 방지된다.
+- **API 모드 (`ANTHROPIC_API_KEY` 설정)** — `API $X.XX today` 형식으로 오늘(UTC 자정 기준) 발생한 비용을 표시. Claude Code가 기록하는 로컬 jsonl 세션 로그를 직접 스캔해 모델별 토큰을 합산하고 Anthropic 공식 가격표 기반으로 USD 환산하므로, 별도 admin key 셋업이 불필요하다.
+
+`CLAUDE_CONFIG_DIR` 환경변수로 다중 OAuth 계정을 분리해 쓰는 경우, statusline의 캐시·키체인 조회·비용 스캔이 모두 본체와 동일한 알고리즘으로 자동 분기된다.
 
 Claude Code는 플러그인이 사용자 `statusLine`을 자동 등록하는 걸 허용하지 않으므로, 별도 CLI로 배포된 `claude-nexus`를 본인의 `~/.claude/settings.json`에 등록한다.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.32.1",
+  "version": "0.33.0",
   "type": "module",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": "kih",

--- a/scripts/statusline.mjs
+++ b/scripts/statusline.mjs
@@ -1,11 +1,12 @@
 #!/usr/bin/env node
 
 // src/statusline/statusline.ts
-import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { execSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
+import { createHash } from "node:crypto";
 var stdinRaw = "";
 try {
   stdinRaw = readFileSync(0, "utf-8");
@@ -29,7 +30,16 @@ function findProjectRoot(start) {
 }
 var PROJECT_ROOT = findProjectRoot(getVal("cwd") || process.cwd());
 var HOME = homedir();
+var CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude");
 var PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || "";
+var KEYCHAIN_SERVICE = (() => {
+  const envDir = process.env.CLAUDE_CONFIG_DIR;
+  if (!envDir)
+    return "Claude Code-credentials";
+  const normalized = envDir.normalize("NFC");
+  const suffix = createHash("sha256").update(normalized).digest("hex").slice(0, 8);
+  return `Claude Code-credentials-${suffix}`;
+})();
 function getPluginVersion() {
   if (PLUGIN_ROOT) {
     try {
@@ -72,7 +82,7 @@ function makeBar(pct, width) {
 function meter(label, pct, width) {
   return `${DIM}${label}${RESET} ${pctColor(pct)}${makeBar(pct, width)} ${Math.round(pct)}%${RESET}`;
 }
-var VERSION_CACHE_PATH = join(HOME, ".claude", ".nexus_version_cache");
+var VERSION_CACHE_PATH = join(CLAUDE_CONFIG_DIR, ".nexus_version_cache");
 var VERSION_CACHE_TTL = 86400;
 function updateAvailable(current) {
   if (!current)
@@ -142,7 +152,7 @@ function buildLine1() {
   const nexusTag = `\x1B[38;5;141m◆Nexus${versionStr}${RESET}${updateTag}`;
   return `${nexusTag} ${SEP} ${modelColor}${BOLD}${model}${RESET} ${SEP} \x1B[36m${project}${RESET} ${SEP} ${gitPart}`;
 }
-var USAGE_CACHE_PATH = join(HOME, ".claude", ".usage_cache");
+var USAGE_CACHE_PATH = join(CLAUDE_CONFIG_DIR, ".usage_cache");
 var CACHE_TTL_DEFAULT = 60;
 var FETCH_BACKOFF = 300;
 var STALE_THRESHOLD = 300;
@@ -166,9 +176,9 @@ ${cachedData}`);
   try {
     let tokenCmd = "";
     if (process.platform === "darwin") {
-      tokenCmd = `TOKEN=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | grep -o '"accessToken":"[^"]*"' | sed 's/"accessToken":"//;s/"//')`;
+      tokenCmd = `TOKEN=$(security find-generic-password -s "${KEYCHAIN_SERVICE}" -w 2>/dev/null | grep -o '"accessToken":"[^"]*"' | sed 's/"accessToken":"//;s/"//')`;
     } else {
-      const credFile = join(HOME, ".claude", ".credentials.json");
+      const credFile = join(CLAUDE_CONFIG_DIR, ".credentials.json");
       tokenCmd = `TOKEN=$(grep -o '"accessToken":"[^"]*"' "${credFile}" 2>/dev/null | sed 's/"accessToken":"//;s/"//')`;
     }
     const script = `
@@ -218,12 +228,12 @@ function readUsage() {
   try {
     let credJson = "";
     if (process.platform === "darwin") {
-      credJson = execSync('security find-generic-password -s "Claude Code-credentials" -w', {
+      credJson = execSync(`security find-generic-password -s "${KEYCHAIN_SERVICE}" -w`, {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"]
       }).trim();
     } else {
-      const credFile = join(HOME, ".claude", ".credentials.json");
+      const credFile = join(CLAUDE_CONFIG_DIR, ".credentials.json");
       if (existsSync(credFile))
         credJson = readFileSync(credFile, "utf-8");
     }
@@ -274,27 +284,177 @@ function resetRemain(parsed, section) {
 function isApiMode() {
   return !!process.env.ANTHROPIC_API_KEY;
 }
-function fetchApiCost(adminKey) {
+var COST_CACHE_PATH = join(CLAUDE_CONFIG_DIR, ".api_cost_cache");
+var COST_CACHE_TTL = 60;
+var COST_STALE_THRESHOLD = 300;
+function priceFor(model) {
+  const m = model.toLowerCase();
+  const TABLE = [
+    [/opus-4-[5-9]/, 5, 25],
+    [/opus-(?:4-[01]|4)(?:[-_]|$)/, 15, 75],
+    [/opus-3/, 15, 75],
+    [/sonnet-4(?:-\d+)?(?:[-_]|$)|4-sonnet/, 3, 15],
+    [/sonnet-3-7|3-7-sonnet/, 3, 15],
+    [/sonnet-3-5|3-5-sonnet/, 3, 15],
+    [/haiku-4-5/, 1, 5],
+    [/haiku-3-5|3-5-haiku/, 0.8, 4],
+    [/haiku-3/, 0.25, 1.25]
+  ];
+  for (const [re, inp, out] of TABLE) {
+    if (re.test(m)) {
+      const inputPerToken = inp / 1e6;
+      return {
+        input: inputPerToken,
+        output: out / 1e6,
+        cache5m: inputPerToken * 1.25,
+        cache1h: inputPerToken * 2,
+        cacheRead: inputPerToken * 0.1
+      };
+    }
+  }
+  return null;
+}
+function turnCostUsd(model, usage) {
+  const rates = priceFor(model);
+  if (!rates)
+    return 0;
+  const inp = usage.input_tokens ?? 0;
+  const out = usage.output_tokens ?? 0;
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  const c5m = usage.cache_creation?.ephemeral_5m_input_tokens;
+  const c1h = usage.cache_creation?.ephemeral_1h_input_tokens;
+  let cacheWriteCost = 0;
+  if (c5m !== undefined || c1h !== undefined) {
+    cacheWriteCost = (c5m ?? 0) * rates.cache5m + (c1h ?? 0) * rates.cache1h;
+  } else {
+    cacheWriteCost = (usage.cache_creation_input_tokens ?? 0) * rates.cache5m;
+  }
+  return inp * rates.input + out * rates.output + cacheRead * rates.cacheRead + cacheWriteCost;
+}
+function scanLocalCostUsd() {
+  const projectsRoot = join(CLAUDE_CONFIG_DIR, "projects");
+  if (!existsSync(projectsRoot))
+    return null;
+  const todayStart = new Date;
+  todayStart.setUTCHours(0, 0, 0, 0);
+  const todayStartMs = todayStart.getTime();
+  let total = 0;
+  let projectDirs;
   try {
-    const today = new Date().toISOString().slice(0, 10);
-    const resp = execSync(`curl -s --max-time 3 "https://api.anthropic.com/v1/organizations/cost_report?start_date=${today}&end_date=${today}" -H "x-api-key: ${adminKey}" -H "anthropic-version: 2023-06-01"`, { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] }).trim();
-    const m = resp.match(/"total_cost"\s*:\s*([0-9.]+)/);
-    return m ? parseFloat(m[1]) : null;
+    projectDirs = readdirSync(projectsRoot);
   } catch {
     return null;
   }
+  for (const proj of projectDirs) {
+    const projPath = join(projectsRoot, proj);
+    let entries;
+    try {
+      entries = readdirSync(projPath);
+    } catch {
+      continue;
+    }
+    for (const file of entries) {
+      if (!file.endsWith(".jsonl"))
+        continue;
+      const fp = join(projPath, file);
+      try {
+        const st = statSync(fp);
+        if (st.mtimeMs < todayStartMs)
+          continue;
+      } catch {
+        continue;
+      }
+      let raw;
+      try {
+        raw = readFileSync(fp, "utf-8");
+      } catch {
+        continue;
+      }
+      const lines = raw.split(`
+`);
+      for (const line of lines) {
+        if (!line || !line.includes('"assistant"'))
+          continue;
+        let entry;
+        try {
+          entry = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (entry.type !== "assistant")
+          continue;
+        const ts = entry.timestamp ? Date.parse(entry.timestamp) : NaN;
+        if (!Number.isFinite(ts) || ts < todayStartMs)
+          continue;
+        const model = entry.message?.model;
+        const usage = entry.message?.usage;
+        if (!model || !usage)
+          continue;
+        total += turnCostUsd(model, usage);
+      }
+    }
+  }
+  return total;
+}
+function writeCostCacheAtomic(content) {
+  try {
+    writeFileSync(COST_CACHE_PATH + ".tmp", content);
+    renameSync(COST_CACHE_PATH + ".tmp", COST_CACHE_PATH);
+  } catch {
+    try {
+      unlinkSync(COST_CACHE_PATH + ".tmp");
+    } catch {}
+  }
+}
+function readApiCost() {
+  const now = Math.floor(Date.now() / 1000);
+  let dataTimestamp = 0;
+  let nextRescanAfter = 0;
+  let cachedValue = "";
+  if (existsSync(COST_CACHE_PATH)) {
+    try {
+      const lines = readFileSync(COST_CACHE_PATH, "utf-8").split(`
+`);
+      dataTimestamp = parseInt(lines[0]) || 0;
+      nextRescanAfter = parseInt(lines[1]) || 0;
+      cachedValue = (lines[2] || "").trim();
+    } catch {}
+  }
+  const age = dataTimestamp > 0 ? now - dataTimestamp : 0;
+  const parseCached = () => {
+    if (!cachedValue)
+      return null;
+    const n = parseFloat(cachedValue);
+    return Number.isFinite(n) ? n : null;
+  };
+  if (cachedValue && now < nextRescanAfter) {
+    return { cost: parseCached(), stale: age >= COST_STALE_THRESHOLD, ageSeconds: age };
+  }
+  const cost = scanLocalCostUsd();
+  if (cost === null) {
+    return { cost: null, stale: false, ageSeconds: 0 };
+  }
+  writeCostCacheAtomic(`${now}
+${now + COST_CACHE_TTL}
+${cost}`);
+  return { cost, stale: false, ageSeconds: 0 };
 }
 function buildLine2() {
   const BAR_WIDTH = 6;
   const ctxPct = Math.round(getNum("used_percentage"));
   const ctx = meter("ctx", ctxPct, BAR_WIDTH);
   if (isApiMode()) {
-    const adminKey = process.env.ANTHROPIC_ADMIN_KEY;
-    if (adminKey) {
-      const cost = fetchApiCost(adminKey);
-      if (cost !== null) {
-        return `${ctx} ${SEP} ${DIM}API${RESET} ${pctColor(0)}$${cost.toFixed(2)} today${RESET}`;
+    const { cost, stale, ageSeconds } = readApiCost();
+    if (cost !== null) {
+      let stalePart2 = "";
+      if (stale) {
+        const ageMin = Math.floor(ageSeconds / 60);
+        const hh = Math.floor(ageMin / 60);
+        const mm = ageMin % 60;
+        const ageStr = hh > 0 ? `${hh}h${mm}m` : `${mm}m`;
+        stalePart2 = ` ${SEP} \x1B[33m${ageStr} ago\x1B[0m`;
       }
+      return `${ctx} ${SEP} ${DIM}API${RESET} ${pctColor(0)}$${cost.toFixed(2)} today${RESET}${stalePart2}`;
     }
     return `${ctx} ${SEP} ${DIM}API mode${RESET}`;
   }

--- a/src/statusline/statusline.ts
+++ b/src/statusline/statusline.ts
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 // Nexus statusline — Claude Code statusLine.command
 // Reads JSON session data on stdin (display_name, used_percentage, cwd, etc.)
-// Cross-session cache at ~/.claude/.usage_cache prevents concurrent fetches.
+// Cross-session cache at $CLAUDE_CONFIG_DIR/.usage_cache (default ~/.claude) prevents concurrent fetches.
 
-import { existsSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { execSync, spawn } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { homedir } from "node:os";
+import { createHash } from "node:crypto";
 
 // ── stdin ──────────────────────────────────────────────
 
@@ -40,7 +41,20 @@ function findProjectRoot(start?: string): string {
 
 const PROJECT_ROOT = findProjectRoot(getVal("cwd") || process.cwd());
 const HOME = homedir();
+const CLAUDE_CONFIG_DIR = process.env.CLAUDE_CONFIG_DIR || join(HOME, ".claude");
 const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || "";
+
+// macOS keychain service name. Mirrors Claude Code's own algorithm:
+//   default (CLAUDE_CONFIG_DIR unset) → "Claude Code-credentials"
+//   custom CLAUDE_CONFIG_DIR          → "Claude Code-credentials-<sha256(NFC(envValue))[:8]>"
+// Hash input is the env-var value verbatim (NFC-normalized), not a resolved path.
+const KEYCHAIN_SERVICE = (() => {
+  const envDir = process.env.CLAUDE_CONFIG_DIR;
+  if (!envDir) return "Claude Code-credentials";
+  const normalized = envDir.normalize("NFC");
+  const suffix = createHash("sha256").update(normalized).digest("hex").slice(0, 8);
+  return `Claude Code-credentials-${suffix}`;
+})();
 
 function getPluginVersion(): string {
   // Plugin context: Claude Code sets CLAUDE_PLUGIN_ROOT when loading from marketplace.
@@ -95,7 +109,7 @@ function meter(label: string, pct: number, width: number): string {
 
 // ── Line 1: Nexus tag · model · project · branch ──────
 
-const VERSION_CACHE_PATH = join(HOME, ".claude", ".nexus_version_cache");
+const VERSION_CACHE_PATH = join(CLAUDE_CONFIG_DIR, ".nexus_version_cache");
 const VERSION_CACHE_TTL = 86400; // 24h
 
 function updateAvailable(current: string): boolean {
@@ -183,7 +197,7 @@ function buildLine1(): string {
 
 // ── Line 2: ctx · 5h · 7d with cross-session cache ────
 
-const USAGE_CACHE_PATH = join(HOME, ".claude", ".usage_cache");
+const USAGE_CACHE_PATH = join(CLAUDE_CONFIG_DIR, ".usage_cache");
 const CACHE_TTL_DEFAULT = 60; // s
 const FETCH_BACKOFF = 300; // s on failure
 const STALE_THRESHOLD = 300; // show "ago" when data older than 5 min
@@ -218,10 +232,9 @@ function triggerBackgroundFetch(dataTimestamp: number, cachedData: string): void
   try {
     let tokenCmd = "";
     if (process.platform === "darwin") {
-      tokenCmd =
-        'TOKEN=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null | grep -o \'"accessToken":"[^"]*"\' | sed \'s/"accessToken":"//;s/"//\')';
+      tokenCmd = `TOKEN=$(security find-generic-password -s "${KEYCHAIN_SERVICE}" -w 2>/dev/null | grep -o '"accessToken":"[^"]*"' | sed 's/"accessToken":"//;s/"//')`;
     } else {
-      const credFile = join(HOME, ".claude", ".credentials.json");
+      const credFile = join(CLAUDE_CONFIG_DIR, ".credentials.json");
       tokenCmd = `TOKEN=$(grep -o '"accessToken":"[^"]*"' "${credFile}" 2>/dev/null | sed 's/"accessToken":"//;s/"//')`;
     }
 
@@ -283,12 +296,12 @@ function readUsage(): { json: string; stale: boolean; ageSeconds: number } | nul
   try {
     let credJson = "";
     if (process.platform === "darwin") {
-      credJson = execSync('security find-generic-password -s "Claude Code-credentials" -w', {
+      credJson = execSync(`security find-generic-password -s "${KEYCHAIN_SERVICE}" -w`, {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
       }).trim();
     } else {
-      const credFile = join(HOME, ".claude", ".credentials.json");
+      const credFile = join(CLAUDE_CONFIG_DIR, ".credentials.json");
       if (existsSync(credFile)) credJson = readFileSync(credFile, "utf-8");
     }
     const tokenMatch = credJson.match(/"accessToken"\s*:\s*"([^"]+)"/);
@@ -344,18 +357,220 @@ function isApiMode(): boolean {
   return !!process.env.ANTHROPIC_API_KEY;
 }
 
-function fetchApiCost(adminKey: string): number | null {
+// ── API cost (local jsonl scan) ───────────────────────
+// Sums today's token usage across all Claude Code sessions on this machine and
+// converts to USD using a hardcoded model price table. Avoids needing an
+// ANTHROPIC_ADMIN_KEY (cost_report admin endpoint) — works for every API mode user.
+//
+// "Today" = UTC midnight → next UTC midnight, matching Claude Code desktop app.
+//
+// Price table source: https://platform.claude.com/docs/en/about-claude/pricing
+// Cache pricing rule: cache_5m = 1.25× input, cache_1h = 2× input, cache_read = 0.1× input.
+
+const COST_CACHE_PATH = join(CLAUDE_CONFIG_DIR, ".api_cost_cache");
+const COST_CACHE_TTL = 60; // s
+const COST_STALE_THRESHOLD = 300; // s — mark stale at 5 min
+
+interface ModelRates {
+  input: number; // USD per token (already divided by 1e6)
+  output: number;
+  cache5m: number;
+  cache1h: number;
+  cacheRead: number;
+}
+
+/**
+ * Map a Claude API model name (e.g. "claude-opus-4-7", "claude-3-5-sonnet-20241022")
+ * to per-token USD rates. Returns null for unknown models so they're excluded
+ * from the total rather than mis-priced. Verified 2026-04 against pricing page.
+ */
+function priceFor(model: string): ModelRates | null {
+  const m = model.toLowerCase();
+  // [pattern, base $/MTok input, $/MTok output]
+  const TABLE: Array<[RegExp, number, number]> = [
+    [/opus-4-[5-9]/, 5, 25], // Opus 4.5 / 4.6 / 4.7
+    [/opus-(?:4-[01]|4)(?:[-_]|$)/, 15, 75], // Opus 4 / 4.1
+    [/opus-3/, 15, 75], // Opus 3 (deprecated)
+    [/sonnet-4(?:-\d+)?(?:[-_]|$)|4-sonnet/, 3, 15], // Sonnet 4 / 4.5 / 4.6
+    [/sonnet-3-7|3-7-sonnet/, 3, 15], // Sonnet 3.7 (deprecated)
+    [/sonnet-3-5|3-5-sonnet/, 3, 15], // Sonnet 3.5 (legacy, same rate)
+    [/haiku-4-5/, 1, 5],
+    [/haiku-3-5|3-5-haiku/, 0.8, 4],
+    [/haiku-3/, 0.25, 1.25],
+  ];
+  for (const [re, inp, out] of TABLE) {
+    if (re.test(m)) {
+      const inputPerToken = inp / 1e6;
+      return {
+        input: inputPerToken,
+        output: out / 1e6,
+        cache5m: inputPerToken * 1.25,
+        cache1h: inputPerToken * 2,
+        cacheRead: inputPerToken * 0.1,
+      };
+    }
+  }
+  return null;
+}
+
+interface TurnUsage {
+  input_tokens?: number;
+  output_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_creation_input_tokens?: number;
+  cache_creation?: {
+    ephemeral_5m_input_tokens?: number;
+    ephemeral_1h_input_tokens?: number;
+  };
+}
+
+function turnCostUsd(model: string, usage: TurnUsage): number {
+  const rates = priceFor(model);
+  if (!rates) return 0;
+  const inp = usage.input_tokens ?? 0;
+  const out = usage.output_tokens ?? 0;
+  const cacheRead = usage.cache_read_input_tokens ?? 0;
+  // Prefer detailed 5m/1h split if present; else fall back to the aggregate
+  // cache_creation_input_tokens at 5m rate (the safer/cheaper assumption).
+  const c5m = usage.cache_creation?.ephemeral_5m_input_tokens;
+  const c1h = usage.cache_creation?.ephemeral_1h_input_tokens;
+  let cacheWriteCost = 0;
+  if (c5m !== undefined || c1h !== undefined) {
+    cacheWriteCost = (c5m ?? 0) * rates.cache5m + (c1h ?? 0) * rates.cache1h;
+  } else {
+    cacheWriteCost = (usage.cache_creation_input_tokens ?? 0) * rates.cache5m;
+  }
+  return inp * rates.input + out * rates.output + cacheRead * rates.cacheRead + cacheWriteCost;
+}
+
+/**
+ * Walk ~/.claude/projects/<encoded>/<session>.jsonl and sum cost for assistant
+ * turns whose timestamp falls within today's UTC bucket. Returns USD or null
+ * when the projects directory is missing entirely.
+ *
+ * Performance: project files modified before today's UTC midnight are skipped
+ * by mtime so heavy users don't re-scan archival sessions on every render.
+ */
+function scanLocalCostUsd(): number | null {
+  const projectsRoot = join(CLAUDE_CONFIG_DIR, "projects");
+  if (!existsSync(projectsRoot)) return null;
+
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+  const todayStartMs = todayStart.getTime();
+
+  let total = 0;
+  let projectDirs: string[];
   try {
-    const today = new Date().toISOString().slice(0, 10);
-    const resp = execSync(
-      `curl -s --max-time 3 "https://api.anthropic.com/v1/organizations/cost_report?start_date=${today}&end_date=${today}" -H "x-api-key: ${adminKey}" -H "anthropic-version: 2023-06-01"`,
-      { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] },
-    ).trim();
-    const m = resp.match(/"total_cost"\s*:\s*([0-9.]+)/);
-    return m ? parseFloat(m[1]) : null;
+    projectDirs = readdirSync(projectsRoot);
   } catch {
     return null;
   }
+
+  for (const proj of projectDirs) {
+    const projPath = join(projectsRoot, proj);
+    let entries: string[];
+    try {
+      entries = readdirSync(projPath);
+    } catch {
+      continue;
+    }
+    for (const file of entries) {
+      if (!file.endsWith(".jsonl")) continue;
+      const fp = join(projPath, file);
+      try {
+        const st = statSync(fp);
+        // Skip files whose last modification is before today — they cannot
+        // contain today-bucket entries.
+        if (st.mtimeMs < todayStartMs) continue;
+      } catch {
+        continue;
+      }
+      let raw: string;
+      try {
+        raw = readFileSync(fp, "utf-8");
+      } catch {
+        continue;
+      }
+      const lines = raw.split("\n");
+      for (const line of lines) {
+        if (!line || !line.includes('"assistant"')) continue;
+        let entry: {
+          type?: string;
+          timestamp?: string;
+          message?: { model?: string; usage?: TurnUsage };
+        };
+        try {
+          entry = JSON.parse(line);
+        } catch {
+          continue;
+        }
+        if (entry.type !== "assistant") continue;
+        const ts = entry.timestamp ? Date.parse(entry.timestamp) : NaN;
+        if (!Number.isFinite(ts) || ts < todayStartMs) continue;
+        const model = entry.message?.model;
+        const usage = entry.message?.usage;
+        if (!model || !usage) continue;
+        total += turnCostUsd(model, usage);
+      }
+    }
+  }
+  return total;
+}
+
+function writeCostCacheAtomic(content: string): void {
+  try {
+    writeFileSync(COST_CACHE_PATH + ".tmp", content);
+    renameSync(COST_CACHE_PATH + ".tmp", COST_CACHE_PATH);
+  } catch {
+    try {
+      unlinkSync(COST_CACHE_PATH + ".tmp");
+    } catch {
+      /* skip */
+    }
+  }
+}
+
+/**
+ * Returns today's API cost in USD with a 60s cache. `null` only when the
+ * Claude projects directory itself is missing (i.e., new install with no
+ * sessions yet). $0 is a valid result for "no usage today."
+ */
+function readApiCost(): { cost: number | null; stale: boolean; ageSeconds: number } {
+  const now = Math.floor(Date.now() / 1000);
+  let dataTimestamp = 0;
+  let nextRescanAfter = 0;
+  let cachedValue = "";
+
+  if (existsSync(COST_CACHE_PATH)) {
+    try {
+      const lines = readFileSync(COST_CACHE_PATH, "utf-8").split("\n");
+      dataTimestamp = parseInt(lines[0]) || 0;
+      nextRescanAfter = parseInt(lines[1]) || 0;
+      cachedValue = (lines[2] || "").trim();
+    } catch {
+      /* skip */
+    }
+  }
+
+  const age = dataTimestamp > 0 ? now - dataTimestamp : 0;
+  const parseCached = (): number | null => {
+    if (!cachedValue) return null;
+    const n = parseFloat(cachedValue);
+    return Number.isFinite(n) ? n : null;
+  };
+
+  if (cachedValue && now < nextRescanAfter) {
+    return { cost: parseCached(), stale: age >= COST_STALE_THRESHOLD, ageSeconds: age };
+  }
+
+  // Synchronous re-scan. Local I/O only; mtime filter keeps it fast.
+  const cost = scanLocalCostUsd();
+  if (cost === null) {
+    return { cost: null, stale: false, ageSeconds: 0 };
+  }
+  writeCostCacheAtomic(`${now}\n${now + COST_CACHE_TTL}\n${cost}`);
+  return { cost, stale: false, ageSeconds: 0 };
 }
 
 function buildLine2(): string {
@@ -364,13 +579,19 @@ function buildLine2(): string {
   const ctx = meter("ctx", ctxPct, BAR_WIDTH);
 
   if (isApiMode()) {
-    const adminKey = process.env.ANTHROPIC_ADMIN_KEY;
-    if (adminKey) {
-      const cost = fetchApiCost(adminKey);
-      if (cost !== null) {
-        return `${ctx} ${SEP} ${DIM}API${RESET} ${pctColor(0)}$${cost.toFixed(2)} today${RESET}`;
+    const { cost, stale, ageSeconds } = readApiCost();
+    if (cost !== null) {
+      let stalePart = "";
+      if (stale) {
+        const ageMin = Math.floor(ageSeconds / 60);
+        const hh = Math.floor(ageMin / 60);
+        const mm = ageMin % 60;
+        const ageStr = hh > 0 ? `${hh}h${mm}m` : `${mm}m`;
+        stalePart = ` ${SEP} \x1b[33m${ageStr} ago\x1b[0m`;
       }
+      return `${ctx} ${SEP} ${DIM}API${RESET} ${pctColor(0)}$${cost.toFixed(2)} today${RESET}${stalePart}`;
     }
+    // No projects directory yet (fresh install) — fall through to the dim label.
     return `${ctx} ${SEP} ${DIM}API mode${RESET}`;
   }
 


### PR DESCRIPTION
## Summary

statusline에 두 가지 사용자 대면 기능 추가 + 그 과정에서 발견한 stale 의존 코드 정리.

- **CLAUDE_CONFIG_DIR 분리 동작**: Claude Code 본체와 동일한 알고리즘으로 캐시 경로·macOS keychain service 이름·Linux/Windows credential 파일 경로를 분기. 다중 OAuth 계정 환경에서 5h/7d 사용량과 캐시가 더 이상 섞이지 않음.
- **API 모드 자동 비용 표시**: `ANTHROPIC_API_KEY`만 설정해도 statusline에 `API $X.XX today`가 표시됨. 이전엔 `ANTHROPIC_ADMIN_KEY` 보유자만 가능했고 그마저도 cost_report API spec drift로 작동하지 않던 상태였음. 새 구현은 로컬 jsonl 세션 로그를 직접 스캔해 오늘(UTC 자정) 발생한 토큰을 모델별로 합산, Anthropic 공식 가격표 기반 USD 환산.

## Motivation

- 기존 keychain service 이름 하드코딩 때문에 `CLAUDE_CONFIG_DIR`로 띄운 세션이 본체가 저장한 토큰을 못 찾고 항상 기본 계정 토큰을 잘못 읽던 silent bug 해결.
- cost_report admin endpoint는 `start_date`(잘못된 query param)와 `total_cost`(존재하지 않는 응답 필드)에 의존하던 dead code로 admin key 사용자에게도 항상 `API mode` 라벨만 노출되던 문제 해결. 동시에 admin key 셋업 부담을 제거해 API mode 사용자 대부분에게 비용 가시성 확보.

## Changes

### statusline.ts

- `CLAUDE_CONFIG_DIR` 모듈 상수 도입, 캐시 4곳 경로 통일
- macOS keychain service 이름을 본체와 동일한 sha256 suffix 알고리즘으로 동적 생성
- cost_report API 호출/파싱 코드 제거 (`fetchApiCost`, `parseCostReportToUsd`, 백그라운드 셸 스크립트 등 ~150줄 삭제)
- `priceFor(model)` 가격표(18 model 패턴), `turnCostUsd()`, `scanLocalCostUsd()` 추가 (~140줄)
- `readApiCost()` 60s TTL 캐시 (mtime 필터로 archival 세션 스킵, 매 렌더 < 100ms)
- `buildLine2()` API 분기 단순화 (admin key 분기 + `API ?` 빨강 분기 삭제)

### Versions

`0.32.1` → `0.33.0` (minor — 사용자 대면 기능 추가, breaking change 없음)
- `package.json`
- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`

### CHANGELOG

`## [0.33.0] - 2026-04-29` 섹션 추가.

## Test plan

- [x] `bun run clean && bun install --frozen-lockfile` 그린
- [x] `bun run build` 그린 (statusline.mjs 16.91 KB)
- [x] `bun run typecheck` 그린
- [x] `bun run test` e2e 전부 ok
- [x] `priceFor()` 18 model 패턴 단위 테스트 18/18 통과
- [x] 합성 데이터 (1Mi + 1Mo Sonnet 4.6) → \$18.00 (수동 계산 일치)
- [x] 실제 jsonl 스캔 → 오늘 비용 정상 표시 (\$51.96)
- [x] OAuth 모드 회귀 없음
- [x] CLAUDE_CONFIG_DIR 미설정/설정/매치없음 3 시나리오 모두 정상 (이전 PR에서 검증)
- [x] stale 6m → 노란 `Xm ago` 태그 표시
- [x] Validate 워크플로 그린불 대기

## Risks / Notes

- **가격표 maintenance**: Anthropic이 새 모델 출시하면 패치 릴리즈 필요. 알 수 없는 모델은 silent skip → over-report 안 되지만 under-report 가능.
- **jsonl 포맷 의존**: `~/.claude/projects/<encoded>/<session>.jsonl`은 Claude Code 내부 포맷이고 공식 stable API 아님. 본체가 포맷 변경하면 비용 0으로 표시됨.
- **변형 가격 미반영**: web search ($10/1k searches), code execution session-runtime, fast mode 6×, data residency 1.1×, batch 50% 할인 — Claude Code 일반 사용에선 발생하지 않는 케이스라 의도적 단순화.
- **Windows**: statusline 자체가 셸(`sh`/`curl`/`grep`/`sed`) 의존성이 있어 WSL/Git Bash 없이는 동작하지 않음 (이번 릴리스 범위 밖).
- **사용자 조치 불필요**: 플러그인 업데이트 후 자동 적용. `ANTHROPIC_ADMIN_KEY`는 더 이상 사용되지 않지만 설정돼 있어도 에러는 아님.

🤖 Generated with [Claude Code](https://claude.com/claude-code)