### PR TITLE
fix: adopt nexus-core v0.20.1 — tighten HOW collaboration (v0.33.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "claude-nexus",
       "description": "Claude Code plugin for nexus-core agent orchestration",
-      "version": "0.33.0",
+      "version": "0.33.1",
       "author": {
         "name": "kih"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": {
     "name": "kih"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.33.1] - 2026-04-30
+
+### Changed
+
+- `@moreih29/nexus-core` **v0.20.0 → v0.20.1** 채택 (upstream PR #69, "chore(spec): tighten HOW collaboration in plan/auto-plan skills"). nx-plan / nx-auto-plan에서 Lead 단독 추론으로 권고안·결정을 만드는 경로를 spec 차원에서 차단. (1) **nx-auto-plan** — Core Rule이 3개 → 4개로 확장되며 **HOW/researcher/explore 협업이 Rule #1로 승격**(안건 도메인에 맞는 HOW 스폰이 default, 생략하려면 분석 텍스트에 사유 명시). 기존 "never stop"은 사용자 확인 대기 vs HOW 결과 대기로 분리되어 "HOW 결과를 기다리는 것은 멈춤이 아니다"가 명문화됨. (2) **nx-plan** — Supplementary Rule 1개 추가: `MUST gather multi-angle evidence before presenting a recommendation`. Identity·Core Rule은 불변. 영향받은 sync 산출물: `skills/nx-plan/SKILL.md`, `skills/nx-auto-plan/SKILL.md`. agents/* 및 nx-run skill, MCP 인터페이스 변경 없음.
+
+### Notes
+
+- 사용자 조치 불필요. Trigger 태그(`[plan]`, `[auto-plan]`)·MCP 도구·hook·statusline 모두 동일하며 플러그인 업데이트 시 새 spec이 자동 적용된다.
+- 사용자가 인지 가능한 동작 변화: `[auto-plan]` 호출 시 안건마다 HOW 서브에이전트 스폰이 default가 되어 분석 깊이가 일관되게 강화된다 — 이전엔 Lead 단독 숙의로 빠르게 결정되던 안건도 도메인이 명확하면 HOW를 거친다. 사소한 안건이거나 `.nexus/memory`/`context`/`history`에 동일 분석이 있으면 Lead 단독 결정도 허용되며, 이때 사유가 분석 텍스트에 명시된다.
+
 ## [0.33.0] - 2026-04-29
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "claude-nexus",
       "devDependencies": {
-        "@moreih29/nexus-core": "^0.20.0",
+        "@moreih29/nexus-core": "^0.20.1",
         "@types/bun": "^1.3.0",
         "@types/node": "^22.0.0",
         "typescript": "^5.6.0",
@@ -17,7 +17,7 @@
 
     "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
 
-    "@moreih29/nexus-core": ["@moreih29/nexus-core@0.20.0", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0", "yaml": "^2.8.1", "zod": "^4.1.8" }, "bin": { "nexus-mcp": "dist/mcp/server.js", "nexus-sync": "dist/cli/sync.js" } }, "sha512-SrpPVbe7tC+QN26spKz6HRGznFtVK5txc5TIAMhpHKb/bw65ismSi1HqpzdgH1Un7lnYQlLSvcTB5i7juRA0Hg=="],
+    "@moreih29/nexus-core": ["@moreih29/nexus-core@0.20.1", "", { "dependencies": { "@modelcontextprotocol/sdk": "^1.0.0", "yaml": "^2.8.1", "zod": "^4.1.8" }, "bin": { "nexus-mcp": "dist/mcp/server.js", "nexus-sync": "dist/cli/sync.js" } }, "sha512-QtlO2k+Hkd4vQPqCixE3V4bdD44WJAQpIuEbOilt4h+iYfPaumshh/ovm9rUAbyONtFgWkzHPpW9Rr2/d1AMyg=="],
 
     "@types/bun": ["@types/bun@1.3.12", "", { "dependencies": { "bun-types": "1.3.12" } }, "sha512-DBv81elK+/VSwXHDlnH3Qduw+KxkTIWi7TXkAeh24zpi5l0B2kUg9Ga3tb4nJaPcOFswflgi/yAvMVBPrxMB+A=="],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "type": "module",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": "kih",
@@ -40,7 +40,7 @@
     "settings.json"
   ],
   "devDependencies": {
-    "@moreih29/nexus-core": "^0.20.0",
+    "@moreih29/nexus-core": "^0.20.1",
     "@types/bun": "^1.3.0",
     "@types/node": "^22.0.0",
     "typescript": "^5.6.0"

--- a/skills/nx-auto-plan/SKILL.md
+++ b/skills/nx-auto-plan/SKILL.md
@@ -7,17 +7,25 @@ triggers:
 ---
 ## Role
 
-Performs the same research and analysis process as nx-plan, but **Lead makes decisions autonomously without presenting options or waiting for user responses** to produce an execution plan. HOW subagent usage, researcher/explore investigations, prior-knowledge lookup, and issue decomposition are identical to nx-plan. The only difference is at decision time — instead of emitting a comparison table and awaiting user response, Lead deliberates internally and records the decision immediately.
+For each issue, collaborate with HOW subagents (architect/designer/postdoc/strategist), researcher, and explore to gather multi-angle analysis, then synthesize the results so Lead records the decision directly without waiting for a user response.
+
+The flow is as follows:
+
+1. For each issue, dynamically spawn the HOW subagent(s) matching its domain to receive independent analysis.
+2. Use explore when codebase orientation is needed and researcher when external investigation is needed.
+3. Lead synthesizes the gathered analysis, compares candidate options, and selects the most reasonable one.
+4. Decisions are recorded by Lead directly via `nx_plan_decide` without user confirmation; once all issues are decided, brief the user in a single pass.
 
 This skill does not execute. Execution is handled separately by the `[run]` flow. It is also the path `[run]` invokes internally when tasks.json is absent.
 
 ## Core Rules — Absolute Rules
 
-The three rules below are the identity of this skill. **Violating even one makes this plan, not auto-plan.**
+The four rules below are the identity of this skill. **Violating even one departs from auto-plan's intended form.**
 
-1. **Lead decides autonomously.** NEVER ask the user for option choices, delegate decision authority, or request acceptance. All decisions are recorded directly by Lead via `nx_plan_decide` after internal deliberation.
-2. **NEVER produce output that elicits a decision.** Do not emit comparison tables, A/B/C option enumerations, or questions like "which option would you prefer?" to the user. All candidate comparison happens entirely in Lead's internal deliberation; external output is limited to progress status or the final briefing.
-3. **NEVER stop between issues.** Proceed **without interruption** from issue analysis → `nx_plan_decide` → next issue. Do not seek confirmation or give intermediate reports immediately after individual decisions. Reporting happens once in Step 7 after all decisions are made.
+1. **Collaborate with HOW/researcher/explore to analyze each issue.** Spawning the HOW subagent matching the issue's domain is the default; bring in explore for code understanding and researcher for external investigation. Do NOT settle issues by Lead's solo reasoning — to skip collaboration, state the reason (e.g., a trivial issue Lead can decide alone, or identical analysis already present in `.nexus/memory`/`context`/`history`) explicitly in the analysis text.
+2. **Lead decides autonomously.** NEVER ask the user for option choices, delegate decision authority, or request acceptance. All decisions are recorded directly by Lead via `nx_plan_decide` after internal deliberation grounded in the collaboration results.
+3. **NEVER produce output that asks the user to decide.** Do not emit comparison tables, A/B/C option enumerations, or questions like "which option would you prefer?" to the user. However, **the comparison work and per-issue analysis records themselves are normal activity** — candidate comparison happens in Lead's internal deliberation, and its core findings and dismissal rationale are written into the decision text in prose form. They are not externalized, but that does not mean they must not be produced.
+4. **NEVER stop for user confirmation.** Proceed from issue analysis → `nx_plan_decide` → next issue without seeking confirmation or sending intermediate approval requests immediately after individual decisions. The user-facing report happens only once at the Step 7 briefing after all issues are decided. **Waiting for HOW subagent results is not stopping** — when the issue's depth requires it, spawn HOW and wait for the results before deciding. What must not stop is "user confirmation," not "analytical depth."
 
 ## Supplementary Rules
 

--- a/skills/nx-plan/SKILL.md
+++ b/skills/nx-plan/SKILL.md
@@ -29,6 +29,7 @@ If the user requests full delegation such as "you decide" or "whatever you think
 - NEVER execute — this skill's purpose is planning and decision alignment.
 - MUST handle one issue at a time. NEVER present multiple issues simultaneously.
 - NEVER ask groundless questions. MUST investigate code, existing knowledge, and prior decisions first.
+- **MUST gather multi-angle evidence before presenting a recommendation.** Bring in the HOW subagent matching the issue's domain, explore for code understanding, and researcher for external investigation to collect independent analysis before forming the recommendation. NEVER form a recommendation from Lead's solo reasoning.
 - MUST present a comparison table when requesting a decision. NEVER describe options in prose alone.
 - Lead is synthesizer and participant — form independent recommendations and push back when warranted, not merely relay subagent results. **But never take over final decision authority.**
 


### PR DESCRIPTION
## Summary
- Bump `@moreih29/nexus-core` **v0.20.0 → v0.20.1** (upstream PR [#69](https://github.com/moreih29/nexus-core/pull/69) — *chore(spec): tighten HOW collaboration in plan/auto-plan skills*).
- Plugin version **0.33.0 → 0.33.1** (patch — sync-only adoption, no consumer action required).
- Re-synced `skills/nx-plan/SKILL.md` and `skills/nx-auto-plan/SKILL.md`. Other agents/skills, MCP tools, hooks, statusline unchanged.

## Why
Upstream observed that `[auto-plan]` was tending to run as Lead-only deliberation despite the spec claiming "same depth as nx-plan." Root cause: tonal cluster ("decide autonomously / never produce output / never stop") read as "shrink the work," weakening the HOW-spawn default. PR #69 realigns both skills so HOW collaboration depth is equivalent across them — through different mechanisms:
- **nx-plan** — external pressure (comparison table + user wait) + new explicit mandate
- **nx-auto-plan** — new explicit Core Rule

## Spec changes (sync output)
- **nx-auto-plan** — Core Rules 3 → 4. Rule #1 (new): *Collaborate with HOW/researcher/explore to analyze each issue.* "Never stop" split into *user-confirmation wait* (forbidden) vs *HOW-result wait* (allowed). Spawning the domain-matched HOW is now the default; skipping it requires an explicit reason in the analysis text.
- **nx-plan** — Supplementary Rule added: *MUST gather multi-angle evidence before presenting a recommendation. NEVER form a recommendation from Lead's solo reasoning.* Identity and Core Rules untouched.

## Semver — patch
- Upstream is patch (0.20.0 → 0.20.1).
- No consumer action required; trigger tags (`[plan]`, `[auto-plan]`), MCP tool surface, hook contracts, statusline all identical.
- Local change footprint: 2 sync outputs + dependency bump + version metadata + CHANGELOG. `dist/` bytes unchanged (MCP unchanged).
- Direct precedent — 0.19.0→0.19.1, 0.19.1→0.19.2 patch absorptions both shipped as plugin patches (0.31.2, 0.31.3).

## User-visible behavior delta
- `[auto-plan]` will more consistently spawn HOW subagents per issue, increasing analysis depth uniformly. Trivial issues, or those with prior analysis in `.nexus/memory`/`context`/`history`, may still be decided by Lead alone — but the rationale is now required to appear in the analysis text.
- `[plan]` recommendations must be backed by HOW/researcher/explore evidence rather than Lead's solo reasoning.

## Test plan
- [x] `bun run clean && bun install --frozen-lockfile` — lock matches `package.json`
- [x] `bun run build` — sync writes 13/13, MCP/hooks/statusline bundles produced
- [x] `bun run typecheck` — no errors
- [x] `bun run test` — e2e all green (agents, skills, MCP boot, hooks, statusline)
- [x] Idempotency — second `bun run sync` writes 0/13, `git status` clean
- [x] Diff parity — `skills/nx-plan/SKILL.md` and `skills/nx-auto-plan/SKILL.md` diffs match upstream PR #69 (English body) line-for-line
- [ ] After merge: tag `v0.33.1`, push tag, `Publish` workflow green, `gh release create v0.33.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)