### PR TITLE
fix: prompt-router emits fully qualified skill names (v0.34.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "claude-nexus",
       "description": "Claude Code plugin for nexus-core agent orchestration",
-      "version": "0.34.0",
+      "version": "0.34.1",
       "author": {
         "name": "kih"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": {
     "name": "kih"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.34.1] - 2026-05-08
+
+### Fixed
+
+- **`UserPromptSubmit` 훅이 안내하는 스킬 이름에 플러그인 네임스페이스 누락 → `Skill(...)` 호출 실패.** 훅(`prompt-router.ts`)이 `[plan]`·`[auto-plan]`·`[run]` 태그를 받으면 모델에게 "Activate the nx-plan skill ..."처럼 단축명만 안내했고, Claude Code의 `Skill` 도구는 플러그인 스킬에 대해 풀 네임스페이스(`claude-nexus:nx-plan`)를 요구하므로 모델이 그대로 호출하면 `Unknown skill: nx-run`으로 실패했다. 안내 문구를 `claude-nexus:<skill>` 풀네임으로 교체하고 단축명 사용 시 실패한다는 가드 문구를 추가.
+
+### Notes
+
+- 사용자 조치 불필요. 플러그인 업데이트 후 다음 세션부터 자동 적용.
+- 영향 범위: `src/hooks/prompt-router.ts`(`dist/hooks/prompt-router.js` 재빌드). 스킬 본문·에이전트·MCP 인터페이스·statusline 변경 없음.
+
 ## [0.34.0] - 2026-05-08
 
 ### Changed

--- a/dist/hooks/prompt-router.js
+++ b/dist/hooks/prompt-router.js
@@ -17,9 +17,9 @@ async function readStdin() {
 
 // src/hooks/prompt-router.ts
 var DIRECTIVES = {
-  plan: "Activate the nx-plan skill for structured multi-perspective planning.",
-  "auto-plan": "Activate the nx-auto-plan skill to auto-decompose the request into a plan.",
-  run: "Activate the nx-run skill to execute the current plan's tasks.",
+  plan: "Activate the `claude-nexus:nx-plan` skill for structured multi-perspective planning. Pass the fully qualified name to the Skill tool — `nx-plan` alone will fail.",
+  "auto-plan": "Activate the `claude-nexus:nx-auto-plan` skill to auto-decompose the request into a plan. Pass the fully qualified name to the Skill tool — `nx-auto-plan` alone will fail.",
+  run: "Activate the `claude-nexus:nx-run` skill to execute the current plan's tasks. Pass the fully qualified name to the Skill tool — `nx-run` alone will fail.",
   m: "Store the following body as a lesson in .nexus/memory/.",
   "m:gc": "Garbage-collect .nexus/memory/ by merging or removing stale entries.",
   d: "Record a decision for the active plan session's current issue via nx_plan_decide."

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-nexus",
-  "version": "0.34.0",
+  "version": "0.34.1",
   "type": "module",
   "description": "Claude Code plugin for nexus-core agent orchestration",
   "author": "kih",

--- a/src/hooks/prompt-router.ts
+++ b/src/hooks/prompt-router.ts
@@ -1,9 +1,9 @@
 import { readStdin } from "./_stdin.ts";
 
 const DIRECTIVES: Record<string, string> = {
-  "plan": "Activate the nx-plan skill for structured multi-perspective planning.",
-  "auto-plan": "Activate the nx-auto-plan skill to auto-decompose the request into a plan.",
-  "run": "Activate the nx-run skill to execute the current plan's tasks.",
+  "plan": "Activate the `claude-nexus:nx-plan` skill for structured multi-perspective planning. Pass the fully qualified name to the Skill tool — `nx-plan` alone will fail.",
+  "auto-plan": "Activate the `claude-nexus:nx-auto-plan` skill to auto-decompose the request into a plan. Pass the fully qualified name to the Skill tool — `nx-auto-plan` alone will fail.",
+  "run": "Activate the `claude-nexus:nx-run` skill to execute the current plan's tasks. Pass the fully qualified name to the Skill tool — `nx-run` alone will fail.",
   "m": "Store the following body as a lesson in .nexus/memory/.",
   "m:gc": "Garbage-collect .nexus/memory/ by merging or removing stale entries.",
   "d": "Record a decision for the active plan session's current issue via nx_plan_decide.",

--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -87,10 +87,13 @@ echo "{\"hook_event_name\":\"SessionStart\",\"cwd\":\"$tmp\"}" | node dist/hooks
 echo
 echo "[4/5] prompt-router hook"
 out=$(echo '{"hook_event_name":"UserPromptSubmit","prompt":"[plan] decompose the auth refactor"}' | node dist/hooks/prompt-router.js)
-echo "$out" | grep -q 'nx-plan skill' && pass "[plan] → nx-plan directive" || fail "[plan] routing broken: $out"
+echo "$out" | grep -q 'claude-nexus:nx-plan' && pass "[plan] → claude-nexus:nx-plan directive" || fail "[plan] routing broken: $out"
 
 out=$(echo '{"hook_event_name":"UserPromptSubmit","prompt":"[auto-plan] quick task"}' | node dist/hooks/prompt-router.js)
-echo "$out" | grep -q 'nx-auto-plan' && pass "[auto-plan] → nx-auto-plan directive" || fail "[auto-plan] routing broken: $out"
+echo "$out" | grep -q 'claude-nexus:nx-auto-plan' && pass "[auto-plan] → claude-nexus:nx-auto-plan directive" || fail "[auto-plan] routing broken: $out"
+
+out=$(echo '{"hook_event_name":"UserPromptSubmit","prompt":"[run] execute the next task"}' | node dist/hooks/prompt-router.js)
+echo "$out" | grep -q 'claude-nexus:nx-run' && pass "[run] → claude-nexus:nx-run directive" || fail "[run] routing broken: $out"
 
 out=$(echo '{"hook_event_name":"UserPromptSubmit","prompt":"no tag at all"}' | node dist/hooks/prompt-router.js)
 [ -z "$out" ] && pass "no tag → silent" || fail "non-tag prompt emitted output: $out"


### PR DESCRIPTION
## Summary

- `UserPromptSubmit` 훅이 `[plan]` / `[auto-plan]` / `[run]` 태그를 받으면 모델에게 단축명("nx-plan"·"nx-run"·"nx-auto-plan")만 안내했음. Claude Code의 `Skill` 도구는 플러그인 스킬에 대해 풀 네임스페이스(`claude-nexus:<skill>`)를 요구해 호출이 `Unknown skill: nx-run` 으로 실패하던 문제 수정.
- 안내 문구를 ``claude-nexus:nx-plan`` 형태로 교체하고 "단축명만으로 호출하면 실패" 가드 문구 추가.
- e2e 어서션이 단축명 부분문자열을 검사하던 것을 풀네임 검증으로 강화하고, 누락돼 있던 `[run]` 케이스를 추가.
- 버전: 0.34.0 → 0.34.1 (patch — 동작·인터페이스 변경 없는 버그 픽스).

## Risk

- 사용자 조치 불필요. 다음 세션부터 자동 적용.
- 영향 범위는 `src/hooks/prompt-router.ts` (와 재빌드된 `dist/hooks/prompt-router.js`) + `test/e2e.sh`. 스킬 본문·에이전트·MCP 인터페이스·statusline 변경 없음.

## Test plan

- [x] `bun run clean && bun install --frozen-lockfile`
- [x] `bun run build`
- [x] `bun run typecheck`
- [x] `bun run test` (e2e — `[plan]` / `[auto-plan]` / `[run]` 모두 풀네임 검증 통과)
- [ ] CI Validate 워크플로 초록불 확인
- [ ] 병합 후 태그 푸시 → Publish 워크플로 초록불

🤖 Generated with [Claude Code](https://claude.com/claude-code)